### PR TITLE
Wrap bodied of <<if in a <<do

### DIFF
--- a/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
+++ b/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
@@ -393,7 +393,7 @@
                 (second children)]
      :branches
      (if else-marker
-       [if-block else-block]
+       [[(wrap-<<do if-block)] [(wrap-<<do else-block)]]
        [if-block])}))
 
 ;; NOTE: the following forms, like the ones above, are handled specially. They

--- a/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
+++ b/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
@@ -262,12 +262,6 @@
   [_f _children _ramavars]
   {:prefix nil :branches nil})
 
-(defn case-marker
-  [marker-condition]
-  (api/list-node
-   (api/token-node 'case>)
-   marker-condition))
-
 ;; (<<sources s
 ;;   (source> *depot :> [*k *v])
 ;;   (println *k *v)
@@ -313,7 +307,7 @@
            branches)}))
 
 (defmethod split-form '<<subsource
-  [f children ramavars]
+  [f children _ramavars]
   (let [metadata (meta f)
         [_<<subsource data & sources] children
         blocks   (partition-by #(and (api/list-node? %)

--- a/clj-kondo.exports/com.rpl/rama/com/rpl/utils.clj
+++ b/clj-kondo.exports/com.rpl/rama/com/rpl/utils.clj
@@ -7,7 +7,7 @@
 ;;; For debugging...
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn- prnm
+(defn prnm
   "Debug print, with metadata.
 
   Printing metadata can be very important for dealing with clj-kondo hooks

--- a/test/com/rpl/rama_hooks_test.clj
+++ b/test/com/rpl/rama_hooks_test.clj
@@ -3,11 +3,8 @@
    [clj-kondo.hooks-api :as api]
    [clj-kondo.impl.utils :as utils :refer [parse-string]]
    [clojure.test :refer [deftest is testing]]
-   [clojure.walk :as walk]
-   [clojure.pprint :refer [pprint]]
    [com.rpl.errors :as err]
-   [com.rpl.rama-hooks :as rama]
-   [com.rpl.utils :as u]))
+   [com.rpl.rama-hooks :as rama]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Helpers

--- a/test/com/rpl/rama_hooks_test.clj
+++ b/test/com/rpl/rama_hooks_test.clj
@@ -248,7 +248,7 @@
            (body->sexpr
             (transform-sexprs
              '(<<if true (one) (two) (three))))))
-    (is (= '(if true (one) (two) (three))
+    (is (= '(if true (do (one) (two)) (three))
            (body->sexpr
             (transform-sexprs
              '(<<if true (one) (two) (else>) (three)))))))


### PR DESCRIPTION
```clj
(<<if x 
  (prn 1)
  (prn 2)
 (else>)
  (prn 3))
```
was expanding to 
```clj
(if x 
  (prn 1) 
  (prn 2) 
  (prn 3))
```
Instead of 
```clj
(if x 
  (do (prn 1)
      (prn 2))
  (prn 3))
```
Leading to errors there was something besides a binding form at the first form in an `<<if` branch. This fixes it so that the branches of `<<if` are wrapped in a `<<do`.