### PR TITLE
BUG - 0-arity query topologies show odd linting error

### DIFF
--- a/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
+++ b/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
@@ -233,6 +233,15 @@
      ramavars]
   ))
 
+(defn- extract-binding-emits
+  "Separate the input vars from output vars in something like a query topology
+  definition or loop<- bindings"
+  [terms curr-ramavars]
+  (if (and (api/keyword-node? (first terms))
+           (= :> (:k (first terms))))
+    [[] (rest terms)]
+    (extract-emits terms curr-ramavars)))
+
 ;; NOTE: the following implementations of `split-form` are for any form that
 ;; provides multiple branches. Ex. `<<if`, `<<cond`, `<<switch`, etc. These
 ;; then return multiple branches that will have their emit vars checked. This
@@ -555,7 +564,7 @@
   (let [metadata (meta node)
         [_ _topology name input-output & body] (:children node)
         [input new-bindings]
-        (extract-emits (:children input-output) #{})
+        (extract-binding-emits (:children input-output) #{})
         ret-node (with-meta (api/vector-node new-bindings)
                    metadata)
         new-node (with-meta

--- a/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
+++ b/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
@@ -233,6 +233,16 @@
      ramavars]
   ))
 
+;; This is handling the special case in query topologies where the input
+;; ramavars might be empty, but there's still emit vars. Something such as:
+;;   (<<query-topology
+;;     topologies
+;;     "name"
+;;     [:> *ret]
+;;     (identity :x :> *ret))
+;; Without this special handling, and just calling `extract-emits` directly,
+;; it will mistakenly try using `:> *ret` as a binding form, which can cause
+;; confusing linting issues.
 (defn- extract-binding-emits
   "Separate the input vars from output vars in something like a query topology
   definition or loop<- bindings"

--- a/test/com/rpl/rama_hooks_test.clj
+++ b/test/com/rpl/rama_hooks_test.clj
@@ -646,22 +646,42 @@
   (is
    (=
     '(fn
-      name
-      [*url *start-bucket *end-bucket]
-      (|hash *url)
-      (let
-       [[*granularity *gstart *gend]
-        (explode (query-granularities :m *start-bucket *end-bucket))]
+       name
+       []
        (let
-        [*bucket-stat
-         (local-select>
-          [(keypath *url *granularity)
-           (sorted-map-range *gstart *gend) MAP-VALS]
-          $$window-stats)]
-        (|origin)
-        (let
-         [*stats (+combine-measurements *bucket-stat)]
-         [*stats]))))
+           [*ret (identity :x)]
+           [*ret]))
+    (body->sexpr
+     (rama/transform-module-form
+      (->sexpr
+       '(<<query-topology
+         x
+         "name"
+         [:> *ret]
+         (identity :x :> *ret)))
+      nil
+      #{})))
+   "0 arity query topology")
+
+  (is
+   (=
+    '(fn
+       name
+       [*url *start-bucket *end-bucket]
+       (|hash *url)
+       (let
+           [[*granularity *gstart *gend]
+            (explode (query-granularities :m *start-bucket *end-bucket))]
+           (let
+               [*bucket-stat
+                (local-select>
+                 [(keypath *url *granularity)
+                  (sorted-map-range *gstart *gend) MAP-VALS]
+                 $$window-stats)]
+               (|origin)
+               (let
+                   [*stats (+combine-measurements *bucket-stat)]
+                   [*stats]))))
     (-> '(<<query-topology
           topologies
           "name"


### PR DESCRIPTION
0-arity query topologies were getting transformed incorrectly such that 
```clj
(<<query-topology
   x
   "name"
   [:> *ret]
   (identity :x :> *ret))
```
Was getting transformed into 
```clj
(fn name [:> *ret] ...)
```
This was causing a confusing linting error about keywords not being valid binding forms.

This PR just adds special handling for binding forms where `:>` is the first token in the binding vector, indicating that it only has return values. 