### PR TITLE
BUG - inline sets getting rewritten as lists

### DIFF
--- a/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
+++ b/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
@@ -882,6 +882,7 @@
                      (cond
                        (api/vector-node? f) (api/vector-node body)
                        (api/map-node? f) (api/map-node body)
+                       (api/set-node? f) (api/set-node body)
                        :else (api/list-node body))
                      assoc
                      ::ramavars

--- a/test/com/rpl/rama_hooks_test.clj
+++ b/test/com/rpl/rama_hooks_test.clj
@@ -145,6 +145,17 @@
              '(identity 1 :> *one)
              '(pr *one))))))
 
+  (testing "Various collection types"
+    (is
+     (= '(let [*a (identity :a)]
+           (filter> (contains? #{:x :y :z}) [:a :b :c])
+           (identity (into {:a 1 :b 2} [[:c 3] [:d 4]])))
+        (body->sexpr
+         (transform-sexprs
+          '(identity :a :> *a)
+          '(filter> (contains? #{:x :y :z}) [:a :b :c])
+          '(identity (into {:a 1 :b 2} [[:c 3] [:d 4]])))))))
+
   (testing "Destructuring binds"
     (is
      (= '(let


### PR DESCRIPTION
Addresses #4 

There's a switch on node type that makes sure the transformed contents get rewritten into the same node type as it previously was. `api/set-node?` was missing from this list, causing sets to fall into the default case and get rewritten as lists. Ex:
```clj
(constantly (contains? #{"x" "y" "z"} :a))
```
gets rewritten as 
```clj
(constantly (contains? ("z" "x" "y") :a))
```
And this will cause a confusing linting error where it's saying that string is not a function.