### PR TITLE
Add linting for unsupported Clojure features in Rama

### DIFF
--- a/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
+++ b/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
@@ -180,6 +180,82 @@
   ))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Validation
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; NOTE: There are certain contexts in which some forms cannot be used.
+;; For example, throughout Rama's dataflow code, Clojure primitive forms
+;; or macros that expand to them cannot be used.
+;; We want to keep track of the current contexts that forms are being used
+;; in to make sure that illegal usage isn't allowed.
+
+(def illegal-forms
+  '#{declare def defonce defn defn- definline defmacro quote var
+     memfn let letfn set!
+     and or
+     when when-not when-let when-first when-some
+     if if-not if-let if-some
+     cond condp case
+     loop recur doseq dotimes for while
+     binding locking time with-in-str with-out-str with-precision
+     with-local-vars with-open with-redefs with-redefs-fn
+     do try catch finally throw
+     as-> cond-> cond->> some-> some->> .. doto
+     defprotocol extend-type extend-protocol
+     defrecord deftype defmethod defmulti
+     definterface proxy
+     ns import
+     vswap! monitor-enter monitor-exit})
+
+(defn java-method?
+  [form]
+  (let [form-str (str form)]
+    ;; NOTE: clojure reserves symbols starting or ending with `.`, so we know
+    ;; that this will have to be a Java method or constructor call.
+    (or (str/starts-with? form-str ".")
+        (str/ends-with? form-str "."))))
+
+(defn keyword-fn?
+  [form]
+  (let [form-str (str form)]
+    (and (str/starts-with? form-str ":")
+         ;; If it ends with ">" then it's an emit token
+         ;; ex. :> or :err>
+         (not (str/ends-with? form-str ">")))))
+
+(def ^:dynamic *context* nil)
+
+(defmulti ^:private validate-form
+  (fn [form]
+    (let [value (or (:value form) (:k form) form)]
+      (cond
+        (keyword-fn? value) :keyword-fn-form
+        (= 'fn value) :lambda-fn-form
+        (contains? illegal-forms value) :special-form
+        (java-method? value) :java-form
+        :else form))))
+
+(defmethod validate-form :default
+  [_form]
+  true)
+
+(defmethod validate-form :keyword-fn-form
+  [form]
+  (err/maybe-illegal-keyword-fn *context* (meta form)))
+
+(defmethod validate-form :lambda-fn-form
+  [form]
+  (err/maybe-illegal-lambda *context* (meta form)))
+
+(defmethod validate-form :special-form
+  [form]
+  (err/maybe-illegal-special-form *context* (:value form) (meta form)))
+
+(defmethod validate-form :java-form
+  [form]
+  (err/maybe-illegal-java-form *context* (meta form)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Transformers
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -451,6 +527,12 @@
         use-ramavars (api/list-node (list
                                      (api/token-node 'pr)
                                      new-bindings))
+        ;; NOTE: We're inserting a trampoline here because when we transform
+        ;; the body, we don't want the method call symbol to be the first
+        ;; argument. This will cause a linting error since it appears as if the
+        ;; java interop is happening from inside dataflow code (which it is, but
+        ;; normally that's disallowed, so we want to allow it here)
+        linted-expr  (api/list-node (list* 'trampoline (:children expr)))
         new-node     (api/list-node
                       (list*
                        (api/token-node 'let)
@@ -461,7 +543,7 @@
                          new-bindings
                          (api/vector-node [])])
                        (transform-body
-                        (concat [use-ramavars] [expr] following)
+                        (concat [use-ramavars] [linted-expr] following)
                         ramavars)))
         metadata     (meta node)
        ]
@@ -730,6 +812,9 @@
   "
   ([f following] (transform-form f following #{}))
   ([f following ramavars]
+   (when (api/list-node? f)
+     (let [out (validate-form (first (:children f)))]
+       out))
    (if-let [children (and (not (api/token-node? f))
                           (not (api/keyword-node? f))
                           (:children f))]
@@ -972,10 +1057,12 @@
       ;; Anything inside `<<sources` or `<<query-topology` is data-flow code
       ;; for topologies, so that should be parse/re-written as Rama code
       (rama= '<<sources (:value (first children)))
-      (let [[out _following] (transform-form form [] pobjects)]
+      (let [[out _following] (binding [*context* :dataflow]
+                               (transform-form form [] pobjects))]
         [out following])
       (rama= '<<query-topology (:value (first children)))
-      (let [[out _following] (handle-form form [] pobjects)]
+      (let [[out _following] (binding [*context* :dataflow]
+                               (handle-form form [] pobjects))]
         [out following])
 
       :else
@@ -1074,7 +1161,8 @@
                   (list* (api/token-node 'defn)
                          name
                          input
-                         (transform-body children)))]
+                         (binding [*context* :dataflow]
+                           (transform-body children))))]
     (err/maybe-missing-def-name name m)
     (err/maybe-missing-input-vector input m)
 
@@ -1109,7 +1197,8 @@
                      (api/list-node
                       (list*
                        (api/token-node 'do)
-                       (transform-body body)))
+                       (binding [*context* :dataflow]
+                         (transform-body body))))
                      (meta node))]
     {:node (with-meta new-node (meta node))}))
 
@@ -1119,7 +1208,8 @@
   Turns the form into a Clojure `fn`"
   [{:keys [node]}]
   (let [metadata   (meta node)
-        [new-node] (transform-body [node])]
+        [new-node] (binding [*context* :dataflow]
+                     (transform-body [node]))]
     {:node (with-meta new-node metadata)}))
 
 (defn module-hook
@@ -1165,3 +1255,12 @@
     (err/maybe-missing-def-name name m)
     (err/maybe-missing-input-vector input m)
     {:node (with-meta new-node m)}))
+
+(defn foreign-select-hook
+  "Validates that lambda functions aren't used in foreign-select calls"
+  [{:keys [node] :as orig}]
+  (binding [*context* :foreign-select]
+    (->> (api/sexpr node)
+         (flatten)
+         (mapv validate-form)))
+  orig)

--- a/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
+++ b/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
@@ -790,6 +790,10 @@
                           ramavars)))]
     [(with-meta new-node (meta node)) nil]))
 
+(defmethod handle-form 'clj!
+  [node following _ramavars]
+  [node following])
+
 (defn transform-form
   "Given a form, and all forms following it, transforms it such that Rama
   dataflow code's emits and other special forms will be rewritten as `let`s,

--- a/clj-kondo.exports/com.rpl/rama/com/rpl/utils.clj
+++ b/clj-kondo.exports/com.rpl/rama/com/rpl/utils.clj
@@ -41,14 +41,21 @@
   if the token is a prefixed symbol, we make sure that the namespace is a rama
   namespace, and the set contains the simple symbol."
   [symbol-set token]
-  (when token
+  ;; NOTE: this needs to be an `if` returning `false` in the else case, not a
+  ;; `when`. `rama=` is used in `split-form`s, and there was a really weird bug
+  ;; where if the user was trying to call a keyword function (which is illegal
+  ;; in rama anyways), then it would break the partitioning of the blocks,
+  ;; causing a bunch of unresolved symbol errors. With `rama=` returning `false`
+  ;; instead of `nil`, that problem is resolved.
+  (if token
     (let [symbol (api/sexpr token)]
       (if (qualified-symbol? symbol)
         (let [{:keys [name ns]} (api/resolve {:name symbol})]
           (and
            (= ns 'com.rpl.rama)
            (contains? symbol-set name)))
-        (contains? symbol-set symbol)))))
+        (contains? symbol-set symbol)))
+    false))
 
 (defn rama=
   [a b]

--- a/clj-kondo.exports/com.rpl/rama/config.edn
+++ b/clj-kondo.exports/com.rpl/rama/config.edn
@@ -41,7 +41,9 @@
   ;; errors for any forms that belong to the namespaces above, that we tell
   ;; clj-kondo we want to allow `:use` or `:refer :all` with.
   :unresolved-symbol
-  {:exclude [;; com.rpl.rama
+  {:exclude [;; Special compiler internal
+             clj!
+             ;; com.rpl.rama
              recur> defbasicsegmacro defbasicblocksegmacro seg# defoperation
              gen-anyvar gen-anyvars gen-fragvar gen-pstatevar gen-anchorvar
              anyvar? pstatevar? fragvar? anchorvar? if> ?<- defblock <<atomic

--- a/clj-kondo.exports/com.rpl/rama/config.edn
+++ b/clj-kondo.exports/com.rpl/rama/config.edn
@@ -11,6 +11,7 @@
    com.rpl.rama/batch<-               com.rpl.rama-hooks/batch<--hook
    com.rpl.rama/defmodule             com.rpl.rama-hooks/defmodule-hook
    com.rpl.rama/module                com.rpl.rama-hooks/module-hook
+   com.rpl.rama/foreign-select        com.rpl.rama-hooks/foreign-select-hook
 
    defbasicblocksegmacro com.rpl.rama-hooks/defbasicblocksegmacro-hook
    defbasicsegmacro      com.rpl.rama-hooks/defsegmacro-hook
@@ -20,7 +21,8 @@
    defmodule             com.rpl.rama-hooks/defmodule-hook
    module                com.rpl.rama-hooks/module-hook
    ?<-                   com.rpl.rama-hooks/top-level-block-hook
-   batch<-               com.rpl.rama-hooks/batch<--hook}}
+   batch<-               com.rpl.rama-hooks/batch<--hook
+   foreign-select        com.rpl.rama-hooks/foreign-select-hook}}
 
  :lint-as
  {com.rpl.rama/defgenerator        clojure.core/defn

--- a/test/com/rpl/rama_hooks_test.clj
+++ b/test/com/rpl/rama_hooks_test.clj
@@ -1137,6 +1137,35 @@
           (get-error-messages)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Clojure interop tests
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(deftest clj!-test
+  (is (= '(clj! (let [m {:a 1 :b 2}]
+                  (prn (:a m))))
+         (body->sexpr
+          (transform-sexprs
+           '(clj! (let [m {:a 1 :b 2}]
+                    (prn (:a m))))))))
+
+  (is (= '(let [*a (identity 1)]
+            (let [*b (identity 2)]
+              (let [*c (+ 3 (clj!
+                             (let [m {:a *a :b *b}]
+                               (reduce (fn [a v] (+ a v)) (vals m)))))]
+                (prn *c))
+              ))
+         (body->sexpr
+          (transform-sexprs
+           '(identity 1 :> *a)
+           '(identity 2 :> *b)
+           '(+ 3 (clj! (let [m {:a *a :b *b}]
+                         (reduce (fn [a v] (+ a v)) (vals m))))
+               :> *c)
+           '(prn *c)
+          )))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Java interop tests
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/test/com/rpl/rama_hooks_test.clj
+++ b/test/com/rpl/rama_hooks_test.clj
@@ -4,7 +4,8 @@
    [clj-kondo.impl.utils :as utils :refer [parse-string]]
    [clojure.test :refer [deftest is testing]]
    [com.rpl.errors :as err]
-   [com.rpl.rama-hooks :as rama]))
+   [com.rpl.rama-hooks :as rama]
+   [com.rpl.utils :as u]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Helpers
@@ -169,7 +170,37 @@
        (transform-sexprs
         '(identity 1 :> *one)
         '(identity 2 :> *one)
-        '(pr *one)))))))
+        '(pr *one))))))
+
+  (with-testing-context "Err"
+    (binding [rama/*context* :dataflow]
+      (is (= '(let [*map (identity {:a 1 :b 2})]
+                (let [*a (:a *map)]
+                  (when *success?
+                    (letfn
+                        [(%deduct [*curr] (:> (- *curr *amt)))]
+                        (local-transform>
+                         [(keypath *from-user-id)
+                          (term %deduct)]
+                         $$funds)))))
+             (body->sexpr
+              (transform-sexprs
+               '(identity {:a 1 :b 2} :> *map)
+               '(:a *map :> *a)
+               '(<<if
+                 *success?
+                 (<<ramafn
+                  %deduct [*curr]
+                  (:> (- *curr *amt)))
+                 (local-transform>
+                  [(keypath *from-user-id) (term %deduct)] $$funds)))))))
+
+    (is (= err/syntax-error-keyword-fn-in-dataflow
+          (-> utils/*ctx*
+              :findings
+              deref
+              first
+              :message)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Top level forms tests
@@ -1674,3 +1705,138 @@
          (node->sexpr
           (rama/defmodule-hook
            (sexpr->node top-users-module-code))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Illegal contexts tests
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(deftest keywords-as-fns-are-illegal-in-dataflow-test
+  (with-testing-context
+      "Can't have fn appear in foreign-select contexts"
+
+    (binding [rama/*context* :dataflow]
+
+      (body->sexpr
+       (transform-sexprs
+        '(identity {:a 1 :b 2} :> *map)
+        '(:a *map :> *val)))
+
+      (is (= err/syntax-error-keyword-fn-in-dataflow
+             (-> utils/*ctx*
+                 :findings
+                 deref
+                 first
+                 :message))))))
+
+(deftest lambda-are-illegal-in-multiple-contexts-test
+  (with-testing-context
+      "Can't have fn appear in foreign-select contexts"
+      (rama/foreign-select-hook
+       (sexpr->node '(foreign-select [:x (view (fn [x] (inc x)))]
+                                     $$pstate)))
+      (is (= err/syntax-error-lambda-fn-in-foreign-select
+             (-> utils/*ctx*
+                 :findings
+                 deref
+                 first
+                 :message))))
+
+  (with-testing-context
+      "Can't use fn in dataflow code contexts"
+    (binding [rama/*context* :dataflow]
+      (body->sexpr
+       (transform-sexprs
+        '(foreign-select [:x (view (fn [x] (inc x)))]
+                         $$pstate)))
+      (is (= (err/syntax-error-illegal-special-form 'fn)
+             (-> utils/*ctx*
+                 :findings
+                 deref
+                 first
+                 :message))))))
+
+(deftest special-forms-are-illegal-in-dataflow-test
+  (binding [rama/*context* :dataflow]
+    (doseq [form rama/illegal-forms]
+      (with-testing-context
+          (str "Can't use " form " in dataflow code.")
+
+          (body->sexpr
+           (transform-sexprs
+            '(when true? (println "true"))))
+
+          (is (= (err/syntax-error-illegal-special-form 'when)
+                 (-> utils/*ctx*
+                     :findings
+                     deref
+                     first
+                     :message)))))))
+
+(deftest java-method-calls-and-constructors-are-illegal-in-dataflow-test
+  (with-testing-context
+      "Java constructors and method calls are illegal in dataflow code"
+
+    (binding [rama/*context* :dataflow]
+
+      (body->sexpr
+       (transform-sexprs
+        '(HashMap. :> *map)
+        '(.set *map :a 1)))
+
+      (is (= [err/syntax-error-java-interop-in-dataflow
+              err/syntax-error-java-interop-in-dataflow]
+             (->> utils/*ctx*
+                 :findings
+                 deref
+                 (mapv :message)))))))
+
+(def bank-transfer-module-with-error-code
+  '(defmodule BankTransferModule
+     [setup topologies]
+     (declare-depot setup *transfer-depot (hash-by :from-user-id))
+     (let [mb (microbatch-topology topologies "banking")]
+       (declare-pstate mb $$funds {Long Long})
+       (<<sources
+        mb
+        (source> *transfer-depot :> %microbatch)
+        (%microbatch :> {:keys [*success? *from-user-id *amt]})
+        (identity {:a 1 :b 2} :> *map)
+        (:a *map :> *a)
+        (<<if
+         *success?
+         (<<ramafn
+          %deduct [*curr]
+          (:> (- *curr *amt)))
+         (local-transform>
+          [(keypath *from-user-id) (term %deduct)] $$funds))))))
+
+(def bank-transfer-module-with-error-code-transformed
+  '(defn BankTransferModule
+     [setup topologies]
+     (let [*transfer-depot (declare-depot setup (hash-by :from-user-id))]
+       (pr *transfer-depot)
+       (let [mb (microbatch-topology topologies "banking")]
+         (let [$$funds (declare-pstate mb {Long Long})]
+           (pr $$funds)
+           (fn
+             []
+             (let [%microbatch (source> *transfer-depot)]
+               (let [{:keys [*success? *from-user-id *amt]} (%microbatch)]
+                 (let [*map (identity {:a 1 :b 2})]
+                   (let [*a (:a *map)]
+                     (when *success?
+                       (letfn
+                           [(%deduct [*curr] (:> (- *curr *amt)))]
+                           (local-transform>
+                            [(keypath *from-user-id)
+                             (term %deduct)]
+                            $$funds)))))))))))))
+
+(deftest bank-transfer-module-with-errors-test
+  (println "=============================================")
+  (with-testing-context
+      "Should error in multiple places"
+      (is (= bank-transfer-module-with-error-code-transformed
+             (node->sexpr
+              (rama/defmodule-hook
+                (sexpr->node bank-transfer-module-with-error-code)))))))

--- a/test/com/rpl/rama_hooks_test.clj
+++ b/test/com/rpl/rama_hooks_test.clj
@@ -1833,7 +1833,6 @@
                             $$funds)))))))))))))
 
 (deftest bank-transfer-module-with-errors-test
-  (println "=============================================")
   (with-testing-context
       "Should error in multiple places"
       (is (= bank-transfer-module-with-error-code-transformed


### PR DESCRIPTION
This PR adds linting to error on unsupported usage of certain Clojure features in Rama dataflow code. There's 4 things it checks for:
- Use of keywords as functions (ex. `(:a {:a 1 :b 2})` as opposed to `(get {:a 1 :b 2} :a)`)
- Use of Java methods or constructors (ex. `(.get myMap "key" :> *val)`)
- Use of Clojure primitives or clojure.core macros that expand to those primitives
  - Other macros expanding to use of Clojure primitives won't be caught in linting, will need to rely on the compiler for those 
- Use of anonymous functions inside `foreign-select`
  - Note: This only captures anonymous functions declared inline in the foreign-select code, if the function is bound in a `let` and used in the foreign-select, that will not cause an error 