### PR TITLE
BUG - ramavars didn't unify if they weren't the first ramavar

### DIFF
--- a/clj-kondo.exports/com.rpl/rama/com/rpl/errors.clj
+++ b/clj-kondo.exports/com.rpl/rama/com/rpl/errors.clj
@@ -151,7 +151,6 @@ The worker will be unable to deserialize the function.")
 
 (defn maybe-illegal-lambda
   [context metadata]
-  (println context)
   (cond
     (= context :dataflow)
     (error! (syntax-error-illegal-special-form 'fn) metadata)

--- a/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
+++ b/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
@@ -813,7 +813,7 @@
   [node following _ramavars]
   [node following])
 
-(defn transform-form
+(defn transform-form*
   "Given a form, and all forms following it, transforms it such that Rama
   dataflow code's emits and other special forms will be rewritten as `let`s,
   with the following forms nested inside the body of the `let`.
@@ -833,7 +833,7 @@
         (println *z)
         ...)))
   "
-  ([f following] (transform-form f following #{}))
+  ([f following] (transform-form* f following #{}))
   ([f following ramavars]
    (when (api/list-node? f)
      (let [out (validate-form (first (:children f)))]
@@ -915,6 +915,7 @@
              (or new-bindings rebinds)
              [(let [ramavars     (into ramavars new-vars)
                     follows      (transform-body following ramavars)
+                    ramavars     (into ramavars (::ramavars (meta follows)))
                     ;; HACK: This insertion of a call to `trampoline` is
                     ;; actually important. For whatever reason, clojure-lsp
                     ;; doesn't provide the regular editor support for things
@@ -997,6 +998,12 @@
                      (::ramavars (meta body))))
                   following]))))))
      [f following])))
+
+(defn transform-form
+  ([f following] (transform-form* f following #{}))
+  ([f following ramavars]
+   (let [[node _following :as out] (transform-form* f following ramavars)]
+     out)))
 
 (defn transform-body
   "Transform a sequence of rewrite nodes representing Rama forms.

--- a/test/com/rpl/rama_hooks_test.clj
+++ b/test/com/rpl/rama_hooks_test.clj
@@ -374,6 +374,56 @@
             (identity 2 :> *x))
           '(+ *x 1 :> *y))))))
 
+  (testing "Nested conditional unification"
+    (is
+     (=
+      '(let
+        [*b nil
+         _ (if true
+             (do
+               (prn "if")
+               (let
+                [*a (identity 1)]
+                (prn *a)
+                (let
+                 [*b (identity 2)]
+                 {*b *b})))
+             (do
+               (prn "else")
+               (let
+                [*b nil
+                 _ (cond
+                     (case> *x)
+                     (let [*b (identity 3)] {*b *b})
+                     (case> *y)
+                     (let [*b (identity 4)] {*b *b})
+                     (default>)
+                     (let [*b (identity 5)] {*b *b}))]
+                (prn *b)
+                (let
+                 [*c (identity 6)]
+                 {*b *b}))))]
+        (prn *b))
+      (body->sexpr
+       (transform-sexprs
+        '(<<if true
+           (prn "if")
+           (identity 1 :> *a)
+           (prn *a)
+           (identity 2 :> *b)
+          (else>)
+           (prn "else")
+           (<<cond
+            (case> *x)
+             (identity 3 :> *b)
+            (case> *y)
+             (identity 4 :> *b)
+            (default>)
+             (identity 5 :> *b))
+           (prn *b)
+           (identity 6 :> *c))
+        '(prn *b))))))
+
   (with-testing-context
    "Can't have multiple else>s"
    (is (= '(if true (one) (two))


### PR DESCRIPTION
For example:
```clj
(<<if *condition
  (identity 1 :> *a)
  (identity 2 :> *b)
 (else>)
  (identity 3 :> *b)
  (identity 4 :> *c))
(println *b)
```
Previously, `*b` wasn't unifying since in the `then` branch it wasn't the first bound symbol. The ramavars weren't being propagated back up the callstack properly when new ones were bound.

This is now resolved so they should unify no matter where in the branches they appear. 