### PR TITLE
better gathering of emits to multiple output streams (including anchors)

### DIFF
--- a/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
+++ b/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
@@ -991,7 +991,6 @@
                                     (api/list-node
                                      [(api/token-node 'identity) %]))
                                   rebinds)
-                    _ (println "found" found-anchors)
                     anchor-binds (mapcat #(vector
                                            %
                                            (api/token-node nil))
@@ -1054,7 +1053,7 @@
 (defn transform-form
   ([f following] (transform-form* f following #{}))
   ([f following ramavars]
-   (let [[node _following :as out] (transform-form* f following ramavars)]
+   (let [[_node _following :as out] (transform-form* f following ramavars)]
      out)))
 
 (defn transform-body

--- a/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
+++ b/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
@@ -348,6 +348,25 @@
         (throw (ex-info "Unexpected state in extract-emits" {:state state :term current-term})))))
   )
 
+(defn- extract-emits
+  "Separate the output vars from an expression."
+  [terms curr-ramavars]
+  (let [[exprs zero-arity-out out] (partition-by ; split output streams
+                                    (fn [x] (= :> (:k x)))
+                                    (rest terms))
+        [exprs out] (if (and (api/keyword-node? (first exprs))
+                             (= :> (:k (first exprs))))
+                      [[] zero-arity-out]
+                      [exprs out])
+        ramavars    (find-all-ramavars out)
+        new-vars    (set/difference ramavars curr-ramavars)
+        rebind      (set/intersection ramavars curr-ramavars)]
+    [(concat (list (first terms)) exprs)
+     out
+     (when (seq new-vars) (into [] new-vars))
+     (when (seq rebind) (into [] rebind))
+     ramavars]
+  ))
 
 
 

--- a/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
+++ b/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
@@ -348,9 +348,11 @@
         (throw (ex-info "Unexpected state in extract-emits" {:state state :term current-term})))))
   )
 
-(defn- extract-emits
+#_(defn extract-emits
   "Separate the output vars from an expression."
   [terms curr-ramavars]
+  (println "Terms" terms)
+  (println "curr-ramavars" curr-ramavars)
   (let [[exprs zero-arity-out out] (partition-by ; split output streams
                                     (fn [x] (= :> (:k x)))
                                     (rest terms))
@@ -366,7 +368,7 @@
      (when (seq new-vars) (into [] new-vars))
      (when (seq rebind) (into [] rebind))
      ramavars]
-  ))
+    ))
 
 
 

--- a/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
+++ b/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
@@ -354,30 +354,6 @@
           (throw (ex-info "Unexpected state in extract-emits" {:state state :term current-term}))))))
   )
 
-(defn extract-emits
-  "Separate the output vars from an expression."
-  [terms curr-ramavars]
-  (println "Terms" terms)
-  (println "curr-ramavars" curr-ramavars)
-  (let [[exprs zero-arity-out out] (partition-by ; split output streams
-                                    (fn [x] (= :> (:k x)))
-                                    (rest terms))
-        [exprs out] (if (and (api/keyword-node? (first exprs))
-                             (= :> (:k (first exprs))))
-                      [[] zero-arity-out]
-                      [exprs out])
-        ramavars    (find-all-ramavars out)
-        new-vars    (set/difference ramavars curr-ramavars)
-        rebind      (set/intersection ramavars curr-ramavars)]
-    [(concat (list (first terms)) exprs)
-     out
-     (when (seq new-vars) (into [] new-vars))
-     (when (seq rebind) (into [] rebind))
-     ramavars]
-    ))
-
-
-
 ;; This is handling the special case in query topologies where the input
 ;; ramavars might be empty, but there's still emit vars. Something such as:
 ;;   (<<query-topology

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,7 @@
 {:deps    {clj-kondo/clj-kondo {:mvn/version "2023.10.20"}
            org.clojure/clojure {:mvn/version "1.11.1"}}
  :paths   ["clj-kondo.exports/com.rpl/rama" "test"]
- :aliases {:test {:extra-paths ["test"]}}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {lambdaisland/kaocha {:mvn/version "1.87.1366"}}
+                  ;; run tests with clojure -M:test
+                  :main-opts ["-m" "kaocha.runner"]}}}

--- a/test/com/rpl/rama_hooks_test.clj
+++ b/test/com/rpl/rama_hooks_test.clj
@@ -247,6 +247,14 @@
          (body->sexpr
           (transform-sexprs
            '(identity 1 :other> *three :> *one *two)
+           '(pr *one)))))
+  
+  (is (= '(let [<other> nil
+                [*three *one *two] (identity 1)]
+            (pr *one))
+         (body->sexpr
+          (transform-sexprs
+           '(identity 1 :other> <other> *three :> *one *two)
            '(pr *one))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/com/rpl/rama_hooks_test.clj
+++ b/test/com/rpl/rama_hooks_test.clj
@@ -230,7 +230,7 @@
               first
               :message)))))
 
-(deftest multiple-ouputs
+(deftest multiple-outputs
   (is (= '(let [[*one *two] (identity 1)] (pr *one))
          (body->sexpr
           (transform-sexprs
@@ -255,6 +255,15 @@
          (body->sexpr
           (transform-sexprs
            '(identity 1 :other> <other> *three :> *one *two)
+           '(pr *one)))))
+  
+  (is (= '(let [<other> nil
+                <test> nil
+                [*three *one *two] (identity 1)]
+            (pr *one))
+         (body->sexpr
+          (transform-sexprs
+           '(identity 1 :other> <other> *three :> <test> *one *two)
            '(pr *one))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/com/rpl/rama_hooks_test.clj
+++ b/test/com/rpl/rama_hooks_test.clj
@@ -881,25 +881,6 @@
 
   (is
    (=
-    #_'(fn
-       []
-       (let
-           [$$user-total-spend "$$user-total-spend"]
-         (do
-           (microbatch)
-           (let
-               [*purchase-cents (microbatch)
-                *user-id (identity *user-id)]
-             (|hash *user-id)
-             (let
-                 [[*total-spend-cents] []]
-               (pr
-                $$user-total-spend
-                {*user-id (+sum
-                           *purchase-cents
-                           :new-val> *total-spend-cents)})
-               [*user-id *total-spend-cents])))))
-    
     '(fn
         []
         (let [$$user-total-spend "$$user-total-spend"]

--- a/todo.txt
+++ b/todo.txt
@@ -1,1 +1,0 @@
-fix the problem of emit forms (:> *arg1 *arg2) being treated the same as (operation arg1 arg2 :> *out1 *out2) in emit-forms

--- a/todo.txt
+++ b/todo.txt
@@ -1,0 +1,1 @@
+fix the problem of emit forms (:> *arg1 *arg2) being treated the same as (operation arg1 arg2 :> *out1 *out2) in emit-forms


### PR DESCRIPTION
`(foo 5 :other> <other> *v1 *v2 :> *v)`, would previously erroneously report an error on `<other>`, `*v1`, `*v2`