### PR TITLE
feat: add docstring support to deframaop-hook

### DIFF
--- a/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
+++ b/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
@@ -1251,9 +1251,9 @@
       (err/maybe-missing-input-vector input m)
       
       ;; Build defn form with optional docstring
-      (let [defn-parts (cond-> [(api/token-node 'defn) name]
-                         has-docstring? (conj docstring)
-                         :always (conj input))
+      (let [defn-parts (concat [(api/token-node 'defn) name]
+                               (when has-docstring? [docstring])
+                               [input])
             new-node (api/list-node
                       (concat defn-parts
                               (binding [*context* :dataflow]

--- a/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
+++ b/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
@@ -1242,7 +1242,7 @@
     ;; Validate name first
     (err/maybe-missing-def-name name m)
     
-    ;; Parse optional docstring
+    ;; Detect and extract optional docstring between name and input vector
     (let [has-docstring? (and (seq name-and-rest) (api/string-node? (first name-and-rest)))
           docstring (when has-docstring? (first name-and-rest))
           input (if has-docstring? (second name-and-rest) (first name-and-rest))

--- a/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
+++ b/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
@@ -1238,15 +1238,15 @@
   Turns the form into a Clojure `defn`."
   [{:keys [node]}]
   (let [m        (meta node)
-        [_ name & rest-args] (:children node)]
+        [_ name & name-and-rest] (:children node)]
     ;; Validate name first
     (err/maybe-missing-def-name name m)
     
     ;; Parse optional docstring
-    (let [has-docstring? (and (seq rest-args) (api/string-node? (first rest-args)))
-          docstring (when has-docstring? (first rest-args))
-          input (if has-docstring? (second rest-args) (first rest-args))
-          children (if has-docstring? (drop 2 rest-args) (rest rest-args))]
+    (let [has-docstring? (and (seq name-and-rest) (api/string-node? (first name-and-rest)))
+          docstring (when has-docstring? (first name-and-rest))
+          input (if has-docstring? (second name-and-rest) (first name-and-rest))
+          children (if has-docstring? (drop 2 name-and-rest) (rest name-and-rest))]
       ;; Validate input vector after parsing
       (err/maybe-missing-input-vector input m)
       

--- a/test/com/rpl/rama_hooks/top_level_forms_test.clj
+++ b/test/com/rpl/rama_hooks/top_level_forms_test.clj
@@ -2,7 +2,7 @@
   "Tests for top-level form transformations like defbasicsegmacro, 
    defbasicblocksegmacro, and top-level block hooks."
   (:require
-   [clojure.test :refer [deftest is]]
+   [clojure.test :refer [deftest is testing]]
    [com.rpl.rama-hooks :as rama]
    [com.rpl.test-helpers :refer [node->sexpr sexpr->node]]))
 
@@ -59,9 +59,26 @@
              (sexpr->node '(<<atomic (identity 1 :> *x)))))))))
 
 (deftest defn-like-hook-test
+  ;; Tests transformation of deframaop and deframafn forms to defn.
+  ;; Contracts: both forms support optional docstrings and transform correctly.
   (let [f (fn [form]
             (node->sexpr
              (rama/deframaop-hook
               (sexpr->node form))))]
-    (is (= '(defn f [] (:> nil)) (f '(deframaop f [] (:>)))))
-    (is (= '(defn f [*a] (:> nil)) (f '(deframafn f [*a] (:>)))))))
+    (testing "deframaop without docstring"
+      (is (= '(defn f [] (:> nil)) (f '(deframaop f [] (:>))))))
+    
+    (testing "deframaop with docstring"
+      (is (= '(defn f "A function" [] (:> nil))
+             (f '(deframaop f "A function" [] (:>))))))
+    
+    (testing "deframafn without docstring"
+      (is (= '(defn f [*a] (:> nil)) (f '(deframafn f [*a] (:>))))))
+    
+    (testing "deframafn with docstring"
+      (is (= '(defn f "Takes a value" [*a] (:> nil))
+             (f '(deframafn f "Takes a value" [*a] (:>))))))
+    
+    (testing "deframaop with multi-line docstring"
+      (is (= '(defn f "Line 1\nLine 2" [] (:> nil))
+             (f '(deframaop f "Line 1\nLine 2" [] (:>))))))))

--- a/test/com/rpl/rama_hooks/top_level_forms_test.clj
+++ b/test/com/rpl/rama_hooks/top_level_forms_test.clj
@@ -2,9 +2,11 @@
   "Tests for top-level form transformations like defbasicsegmacro, 
    defbasicblocksegmacro, and top-level block hooks."
   (:require
+   [clj-kondo.impl.utils :as utils]
    [clojure.test :refer [deftest is testing]]
+   [com.rpl.errors :as err]
    [com.rpl.rama-hooks :as rama]
-   [com.rpl.test-helpers :refer [node->sexpr sexpr->node]]))
+   [com.rpl.test-helpers :refer [node->sexpr sexpr->node with-testing-context]]))
 
 (deftest defbasicsegmacro-test
   (is
@@ -81,4 +83,14 @@
     
     (testing "deframaop with multi-line docstring"
       (is (= '(defn f "Line 1\nLine 2" [] (:> nil))
-             (f '(deframaop f "Line 1\nLine 2" [] (:>))))))))
+             (f '(deframaop f "Line 1\nLine 2" [] (:>))))))
+    
+    (with-testing-context
+      "malformed deframaop with docstring but no input vector"
+      (rama/deframaop-hook (sexpr->node '(deframaop f "A doc")))
+      (is (= err/syntax-error-missing-input-vector
+             (-> utils/*ctx*
+                 :findings
+                 deref
+                 first
+                 :message))))))


### PR DESCRIPTION
## Summary

Implements docstring support for `deframaop` and `deframafn` forms, resolving GitHub issue #15.

### Changes
- Changed destructuring from `[_ name input & children]` to `[_ name & rest-args]` to handle optional docstrings
- Added conditional parsing using `api/string-node?` to detect and preserve docstrings
- Improved error handling order to validate form structure before conditional parsing
- Used `concat` with `when` for cleaner docstring inclusion in transformed `defn` forms
- Added comprehensive test coverage for both docstring and non-docstring arities

### Design
The implementation detects docstrings using `(api/string-node? (first rest-args))` and conditionally parses the remaining arguments. This maintains backward compatibility with forms without docstrings while enabling proper handling of forms with docstrings.

### Testing
- Added tests for `deframaop` and `deframafn` with docstrings
- Added test for malformed forms (docstring without input vector)
- All 36 tests pass with 173 assertions
- Verified backward compatibility with existing no-docstring tests

### Commits
- test: add failing tests for deframaop/deframafn docstring support
- feat: add docstring support to deframaop-hook
- fix: validate deframaop name before parsing rest-args
- refactor: rename rest-args to name-and-rest in deframaop-hook
- docs: improve comment precision in deframaop-hook
- test: add malformed deframaop error handling test
- refactor: simplify conditional in deframaop-hook

Fixes #15