### PR TITLE
feat: add cljfmt code formatter with pre-commit hook

### DIFF
--- a/.cljfmt.edn
+++ b/.cljfmt.edn
@@ -1,0 +1,8 @@
+{:indentation? true
+ :remove-surrounding-whitespace? true
+ :remove-trailing-whitespace? true
+ :remove-consecutive-blank-lines? true
+ :insert-missing-whitespace? true
+ :align-associative? false
+ :indents {with-testing-context [[:block 1]]
+           deftest [[:block 1]]}}

--- a/deps.edn
+++ b/deps.edn
@@ -7,4 +7,6 @@
                   :main-opts ["-m" "kaocha.runner"]}
            :dev  {:extra-paths ["test"]}
            :nrepl {:extra-deps {nrepl/nrepl {:mvn/version "1.3.1"}}
-                   :main-opts ["-m" "nrepl.cmdline"]}}}
+                   :main-opts ["-m" "nrepl.cmdline"]}
+           :cljfmt {:extra-deps {dev.weavejester/cljfmt {:mvn/version "0.15.3"}}
+                    :main-opts ["-m" "cljfmt.main"]}}}

--- a/scripts/install-pre-commit-hook.sh
+++ b/scripts/install-pre-commit-hook.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Script to install pre-commit hook for cljfmt
+
+set -e
+
+HOOK_FILE=".git/hooks/pre-commit"
+
+# Create the pre-commit hook
+cat > "$HOOK_FILE" << 'EOF'
+#!/usr/bin/env bash
+# Pre-commit hook to run cljfmt on staged .clj and .edn files
+
+# Get list of staged .clj and .edn files
+FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(clj|edn)$' || true)
+
+if [ -n "$FILES" ]; then
+  echo "Running cljfmt on staged files..."
+  
+  # Run cljfmt fix on each file
+  for file in $FILES; do
+    if [ -f "$file" ]; then
+      clojure -M:cljfmt fix "$file"
+      # Re-stage the file if it was modified
+      git add "$file"
+    fi
+  done
+  
+  echo "cljfmt completed"
+fi
+
+exit 0
+EOF
+
+# Make the hook executable
+chmod +x "$HOOK_FILE"
+
+echo "Pre-commit hook installed at $HOOK_FILE"

--- a/test/com/rpl/rama_hooks/basic_test.clj
+++ b/test/com/rpl/rama_hooks/basic_test.clj
@@ -1,13 +1,13 @@
 (ns com.rpl.rama-hooks.basic-test
-  (:require
-   [clj-kondo.hooks-api :as api]
-   [clojure.test :refer [deftest is testing]]
-   [com.rpl.errors :as err]
-   [com.rpl.rama-hooks :as rama]
-   [com.rpl.test-helpers :refer [body->sexpr
-                                  strip-trampoline
-                                  transform-sexprs
-                                  with-testing-context]]))
+    (:require
+     [clj-kondo.hooks-api :as api]
+     [clojure.test :refer [deftest is testing]]
+     [com.rpl.errors :as err]
+     [com.rpl.rama-hooks :as rama]
+     [com.rpl.test-helpers :refer [body->sexpr
+                                   strip-trampoline
+                                   transform-sexprs
+                                   with-testing-context]]))
 
 ;;; Helpers tests
 
@@ -39,134 +39,134 @@
 
 (deftest rama-trampolined-test
   (testing "Rama var becomes a let"
-    (is (= '(let [*one (trampoline identity 1)] (trampoline pr *one))
-           (api/sexpr
-            (first
-             (transform-sexprs
-              '(identity 1 :> *one)
-              '(pr *one)))))))
+           (is (= '(let [*one (trampoline identity 1)] (trampoline pr *one))
+                  (api/sexpr
+                   (first
+                    (transform-sexprs
+                     '(identity 1 :> *one)
+                     '(pr *one)))))))
 
   (testing "Destructuring binds"
-    (is
-     (= '(let
-          [{:keys [*one *two]} (trampoline hash-map :one 1 :two 2)]
-          (trampoline pr *one))
-        (api/sexpr
-         (first
-          (transform-sexprs
-           '(hash-map :one 1 :two 2 :> {:keys [*one *two]})
-           '(pr *one)))))))
+           (is
+            (= '(let
+                 [{:keys [*one *two]} (trampoline hash-map :one 1 :two 2)]
+                 (trampoline pr *one))
+               (api/sexpr
+                (first
+                 (transform-sexprs
+                  '(hash-map :one 1 :two 2 :> {:keys [*one *two]})
+                  '(pr *one)))))))
 
   (testing "Identity reassignment"
-    (is
-     (=
-      '(let
-        [*one (trampoline identity 1)]
-        (do
-         (trampoline identity 2)
-         (let
-          [*one (identity *one)]
-          (trampoline pr *one))))
-      (api/sexpr
-       (first
-        (transform-sexprs
-         '(identity 1 :> *one)
-         '(identity 2 :> *one)
-         '(pr *one))))))))
+           (is
+            (=
+             '(let
+               [*one (trampoline identity 1)]
+               (do
+                (trampoline identity 2)
+                (let
+                 [*one (identity *one)]
+                 (trampoline pr *one))))
+             (api/sexpr
+              (first
+               (transform-sexprs
+                '(identity 1 :> *one)
+                '(identity 2 :> *one)
+                '(pr *one))))))))
 
 ;;; Basic functionality tests
 
 (deftest rama-test
   (testing "Rama var becomes a let"
-    (is (= '(let [*one (identity 1)] (pr *one))
-           (body->sexpr
-            (transform-sexprs
-             '(identity 1 :> *one)
-             '(pr *one))))))
+           (is (= '(let [*one (identity 1)] (pr *one))
+                  (body->sexpr
+                   (transform-sexprs
+                    '(identity 1 :> *one)
+                    '(pr *one))))))
 
   (testing "Various collection types"
-    (is
-     (= '(let [*a (identity :a)]
-           (filter> (contains? #{:x :y :z}) [:a :b :c])
-           (identity (into {:a 1 :b 2} [[:c 3] [:d 4]])))
-        (body->sexpr
-         (transform-sexprs
-          '(identity :a :> *a)
-          '(filter> (contains? #{:x :y :z}) [:a :b :c])
-          '(identity (into {:a 1 :b 2} [[:c 3] [:d 4]])))))))
+           (is
+            (= '(let [*a (identity :a)]
+                     (filter> (contains? #{:x :y :z}) [:a :b :c])
+                     (identity (into {:a 1 :b 2} [[:c 3] [:d 4]])))
+               (body->sexpr
+                (transform-sexprs
+                 '(identity :a :> *a)
+                 '(filter> (contains? #{:x :y :z}) [:a :b :c])
+                 '(identity (into {:a 1 :b 2} [[:c 3] [:d 4]])))))))
 
   (testing "Destructuring binds"
-    (is
-     (= '(let
-          [{:keys [*one *two]} (hash-map :one 1 :two 2)]
-          (pr *one))
-        (body->sexpr
-         (transform-sexprs
-          '(hash-map :one 1 :two 2 :> {:keys [*one *two]})
-          '(pr *one))))))
+           (is
+            (= '(let
+                 [{:keys [*one *two]} (hash-map :one 1 :two 2)]
+                 (pr *one))
+               (body->sexpr
+                (transform-sexprs
+                 '(hash-map :one 1 :two 2 :> {:keys [*one *two]})
+                 '(pr *one))))))
 
   (testing "Multiple assignments"
-    (is
-     (=
-      '(let
-        [*one (identity 1)]
-        (let
-         [*two (identity 2)]
-         (let
-          [*three (identity 3)]
-          (pr [*one *two *three]))))
-      (body->sexpr
-       (transform-sexprs
-        '(identity 1 :> *one)
-        '(identity 2 :> *two)
-        '(identity 3 :> *three)
-        '(pr [*one *two *three]))))))
+           (is
+            (=
+             '(let
+               [*one (identity 1)]
+               (let
+                [*two (identity 2)]
+                (let
+                 [*three (identity 3)]
+                 (pr [*one *two *three]))))
+             (body->sexpr
+              (transform-sexprs
+               '(identity 1 :> *one)
+               '(identity 2 :> *two)
+               '(identity 3 :> *three)
+               '(pr [*one *two *three]))))))
 
   (testing "Identity reassignment"
-    (is
-     (=
-      '(let
-        [*one (identity 1)]
-        (do
-         (identity 2)
-         (let
-          [*one (identity *one)]
-          (pr *one))))
-      (body->sexpr
-       (transform-sexprs
-        '(identity 1 :> *one)
-        '(identity 2 :> *one)
-        '(pr *one))))))
+           (is
+            (=
+             '(let
+               [*one (identity 1)]
+               (do
+                (identity 2)
+                (let
+                 [*one (identity *one)]
+                 (pr *one))))
+             (body->sexpr
+              (transform-sexprs
+               '(identity 1 :> *one)
+               '(identity 2 :> *one)
+               '(pr *one))))))
 
   (with-testing-context "Err"
     (binding [rama/*context* :dataflow]
-      (is (= '(let [*map (identity {:a 1 :b 2})]
-                (let [*a (:a *map)]
-                  (when *success?
-                    (letfn
-                        [(%deduct [*curr] (:> (- *curr *amt)))]
+             (is (= '(let [*map (identity {:a 1 :b 2})]
+                          (let [*a (:a *map)]
+                               (when *success?
+                                     (letfn
+                                      [(%deduct [*curr] (:> (- *curr *amt)))]
+                                      (local-transform>
+                                       [(keypath *from-user-id)
+                                        (term %deduct)]
+                                       $$funds)))))
+                    (body->sexpr
+                     (transform-sexprs
+                      '(identity {:a 1 :b 2} :> *map)
+                      '(:a *map :> *a)
+                      '(<<if
+                        *success?
+                        (<<ramafn
+                         %deduct [*curr]
+                         (:> (- *curr *amt)))
                         (local-transform>
-                         [(keypath *from-user-id)
-                          (term %deduct)]
-                         $$funds)))))
-             (body->sexpr
-              (transform-sexprs
-               '(identity {:a 1 :b 2} :> *map)
-               '(:a *map :> *a)
-               '(<<if
-                 *success?
-                 (<<ramafn
-                  %deduct [*curr]
-                  (:> (- *curr *amt)))
-                 (local-transform>
-                  [(keypath *from-user-id) (term %deduct)] $$funds)))))))
+                         [(keypath *from-user-id) (term %deduct)] $$funds)))))))
 
     (is (= err/syntax-error-keyword-fn-in-dataflow
-          (-> clj-kondo.impl.utils/*ctx*
-              :findings
-              deref
-              first
-              :message)))))
+           (-> clj-kondo.impl.utils/*ctx*
+               :findings
+               deref
+               first
+               :message)))))
 
 (deftest multiple-outputs
   (is (= '(let [[*one *two] (identity 1)] (pr *one))
@@ -174,31 +174,31 @@
           (transform-sexprs
            '(identity 1 :> *one *two)
            '(pr *one)))))
-  
+
   (is (= '(let [[*one *two *three] (identity 1)] (pr *one))
          (body->sexpr
           (transform-sexprs
            '(identity 1 :> *one *two :other> *three)
            '(pr *one)))))
-  
+
   (is (= '(let [[*three *one *two] (identity 1)] (pr *one))
          (body->sexpr
           (transform-sexprs
            '(identity 1 :other> *three :> *one *two)
            '(pr *one)))))
-  
+
   (is (= '(let [<other> nil
                 [*three *one *two] (identity 1)]
-            (pr *one))
+               (pr *one))
          (body->sexpr
           (transform-sexprs
            '(identity 1 :other> <other> *three :> *one *two)
            '(pr *one)))))
-  
+
   (is (= '(let [<other> nil
                 <test> nil
                 [*three *one *two] (identity 1)]
-            (pr *one))
+               (pr *one))
          (body->sexpr
           (transform-sexprs
            '(identity 1 :other> <other> *three :> <test> *one *two)

--- a/test/com/rpl/rama_hooks/branching_test.clj
+++ b/test/com/rpl/rama_hooks/branching_test.clj
@@ -1,12 +1,12 @@
 (ns com.rpl.rama-hooks.branching-test
-  (:require
-   [clj-kondo.hooks-api :as api]
-   [clj-kondo.impl.utils :as utils]
-   [clojure.test :refer [deftest is testing]]
-   [com.rpl.errors :as err]
-   [com.rpl.test-helpers :refer [body->sexpr get-error-messages
-                                  get-first-error-message sexpr->node
-                                  transform-sexprs with-testing-context]]))
+    (:require
+     [clj-kondo.hooks-api :as api]
+     [clj-kondo.impl.utils :as utils]
+     [clojure.test :refer [deftest is testing]]
+     [com.rpl.errors :as err]
+     [com.rpl.test-helpers :refer [body->sexpr get-error-messages
+                                   get-first-error-message sexpr->node
+                                   transform-sexprs with-testing-context]]))
 
 ;;; Tests for Rama branching constructs: <<if, <<switch, <<cond, <<sources, <<subsource
 ;;; These forms split the dataflow into distinct code paths and support variable unification
@@ -16,469 +16,468 @@
   ;; Contract: transforms <<if to if/when with proper branch handling and variable unification
 
   (testing "<<if"
-    (testing "Happy path"
-      (is (= '(when true (one) (two) (three))
-             (body->sexpr
-              (transform-sexprs
-               '(<<if true (one) (two) (three))))))
-      (is (= '(if true (do (one) (two)) (three))
-             (body->sexpr
-              (transform-sexprs
-               '(<<if true (one) (two) (else>) (three)))))))
+           (testing "Happy path"
+                    (is (= '(when true (one) (two) (three))
+                           (body->sexpr
+                            (transform-sexprs
+                             '(<<if true (one) (two) (three))))))
+                    (is (= '(if true (do (one) (two)) (three))
+                           (body->sexpr
+                            (transform-sexprs
+                             '(<<if true (one) (two) (else>) (three)))))))
 
-    (testing "Unification"
-      (is
-       (= '(let
-            [*x nil
-             _
-             (if
-              true
-              (let [*x (identity 1)] {*x *x})
-              (let [*x (identity 2)] {*x *x}))]
-            (let [*y (+ *x 1)]))
-          (body->sexpr
-           (transform-sexprs
-            '(<<if true (identity 1 :> *x) (else>) (identity 2 :> *x))
-            '(+ *x 1 :> *y)))))
+           (testing "Unification"
+                    (is
+                     (= '(let
+                          [*x nil
+                           _
+                           (if
+                            true
+                            (let [*x (identity 1)] {*x *x})
+                            (let [*x (identity 2)] {*x *x}))]
+                          (let [*y (+ *x 1)]))
+                        (body->sexpr
+                         (transform-sexprs
+                          '(<<if true (identity 1 :> *x) (else>) (identity 2 :> *x))
+                          '(+ *x 1 :> *y)))))
 
-      (is
-       (= '(let
-            [*b nil
-             _
-             (if
-              true
-              (do
-                (let [*a (identity 1)]
-                  (let [*b (identity 2)]
-                    {*b *b})))
-              (do
-                (let [*b (identity 3)]
-                  (let [*c (identity 4)]
-                    {*b *b}))))]
-            (let [*d (+ *b 1)]
-              (let [*e (+ *d 1)]
-                (pr *e))))
-          (body->sexpr
-           (transform-sexprs
-            '(<<if
-              true
-              (identity 1 :> *a)
-              (identity 2 :> *b)
-              (else>)
-              (identity 3 :> *b)
-              (identity 4 :> *c))
-            '(+ *b 1 :> *d)
-            '(+ *d 1 :> *e)
-            '(pr *e)))))
+                    (is
+                     (= '(let
+                          [*b nil
+                           _
+                           (if
+                            true
+                            (do
+                             (let [*a (identity 1)]
+                                  (let [*b (identity 2)]
+                                       {*b *b})))
+                            (do
+                             (let [*b (identity 3)]
+                                  (let [*c (identity 4)]
+                                       {*b *b}))))]
+                          (let [*d (+ *b 1)]
+                               (let [*e (+ *d 1)]
+                                    (pr *e))))
+                        (body->sexpr
+                         (transform-sexprs
+                          '(<<if
+                            true
+                            (identity 1 :> *a)
+                            (identity 2 :> *b)
+                            (else>)
+                            (identity 3 :> *b)
+                            (identity 4 :> *c))
+                          '(+ *b 1 :> *d)
+                          '(+ *d 1 :> *e)
+                          '(pr *e)))))
 
-      (is
-       (= '(let
-            [*x nil
-             _
-             (if
-              true
-              (do (prn "if") (let [*x (identity 1)] {*x *x}))
-              (do (prn "else") (let [*x (identity 2)] {*x *x})))]
-            (let [*y (+ *x 1)]))
-          (body->sexpr
-           (transform-sexprs
-            '(<<if
-              true
-              (prn "if")
-              (identity 1 :> *x)
-              (else>)
-              (prn "else")
-              (identity 2 :> *x))
-            '(+ *x 1 :> *y))))))
+                    (is
+                     (= '(let
+                          [*x nil
+                           _
+                           (if
+                            true
+                            (do (prn "if") (let [*x (identity 1)] {*x *x}))
+                            (do (prn "else") (let [*x (identity 2)] {*x *x})))]
+                          (let [*y (+ *x 1)]))
+                        (body->sexpr
+                         (transform-sexprs
+                          '(<<if
+                            true
+                            (prn "if")
+                            (identity 1 :> *x)
+                            (else>)
+                            (prn "else")
+                            (identity 2 :> *x))
+                          '(+ *x 1 :> *y))))))
 
-    (testing "Nested conditional unification"
-      (is
-       (=
-        '(let
-          [*b nil
-           _ (if true
-               (do
-                 (prn "if")
-                 (let
-                  [*a (identity 1)]
-                  (prn *a)
-                  (let
-                   [*b (identity 2)]
-                   {*b *b})))
-               (do
-                 (prn "else")
-                 (let
-                  [*b nil
-                   _ (cond
-                       (case> *x)
-                       (let [*b (identity 3)] {*b *b})
-                       (case> *y)
-                       (let [*b (identity 4)] {*b *b})
-                       (default>)
-                       (let [*b (identity 5)] {*b *b}))]
-                  (prn *b)
-                  (let
-                   [*c (identity 6)]
-                   {*b *b}))))]
-          (prn *b))
-        (body->sexpr
-         (transform-sexprs
-          '(<<if true
-             (prn "if")
-             (identity 1 :> *a)
-             (prn *a)
-             (identity 2 :> *b)
-             (else>)
-             (prn "else")
-             (<<cond
-              (case> *x)
-              (identity 3 :> *b)
-              (case> *y)
-              (identity 4 :> *b)
-              (default>)
-              (identity 5 :> *b))
-             (prn *b)
-             (identity 6 :> *c))
-          '(prn *b))))))
+           (testing "Nested conditional unification"
+                    (is
+                     (=
+                      '(let
+                        [*b nil
+                         _ (if true
+                               (do
+                                (prn "if")
+                                (let
+                                 [*a (identity 1)]
+                                 (prn *a)
+                                 (let
+                                  [*b (identity 2)]
+                                  {*b *b})))
+                               (do
+                                (prn "else")
+                                (let
+                                 [*b nil
+                                  _ (cond
+                                     (case> *x)
+                                     (let [*b (identity 3)] {*b *b})
+                                     (case> *y)
+                                     (let [*b (identity 4)] {*b *b})
+                                     (default>)
+                                     (let [*b (identity 5)] {*b *b}))]
+                                 (prn *b)
+                                 (let
+                                  [*c (identity 6)]
+                                  {*b *b}))))]
+                        (prn *b))
+                      (body->sexpr
+                       (transform-sexprs
+                        '(<<if true
+                               (prn "if")
+                               (identity 1 :> *a)
+                               (prn *a)
+                               (identity 2 :> *b)
+                               (else>)
+                               (prn "else")
+                               (<<cond
+                                (case> *x)
+                                (identity 3 :> *b)
+                                (case> *y)
+                                (identity 4 :> *b)
+                                (default>)
+                                (identity 5 :> *b))
+                               (prn *b)
+                               (identity 6 :> *c))
+                        '(prn *b))))))
 
-    (with-testing-context
-     "Can't have multiple else>s"
-     (is (= '(if true (one) (two))
-            (-> '(<<if true (one) (else>) (two) (else>) (three))
-                (transform-sexprs)
-                body->sexpr)))
-     (is (= err/syntax-error-multiple-elses
-            (-> utils/*ctx*
-                :findings
-                deref
-                first
-                :message))))
+           (with-testing-context
+            "Can't have multiple else>s"
+             (is (= '(if true (one) (two))
+                    (-> '(<<if true (one) (else>) (two) (else>) (three))
+                        (transform-sexprs)
+                        body->sexpr)))
+             (is (= err/syntax-error-multiple-elses
+                    (-> utils/*ctx*
+                        :findings
+                        deref
+                        first
+                        :message))))
 
-    (with-testing-context
-     "(else>) should have no arguments"
-     (= '(if true (one) (three))
-        (-> (transform-sexprs '(<<if true (one) (else> (two)) (three)))
-            (first)
-            (api/sexpr)))
-     (is (= err/syntax-error-else>-arity
-            (-> utils/*ctx*
-                :findings
-                deref
-                first
-                :message))))))
+           (with-testing-context
+            "(else>) should have no arguments"
+             (= '(if true (one) (three))
+                (-> (transform-sexprs '(<<if true (one) (else> (two)) (three)))
+                    (first)
+                    (api/sexpr)))
+             (is (= err/syntax-error-else>-arity
+                    (-> utils/*ctx*
+                        :findings
+                        deref
+                        first
+                        :message))))))
 
 (deftest <<switch-test
   ;; Test <<switch construct transformation and unification
   ;; Contract: transforms <<switch to cond with case> clauses and variable unification
 
   (testing "<<switch"
-    (testing "Happy path"
-      (is (= '(cond (case> (= :x :y)) (do (one) (two)) (case> (= :x :x)) (three))
+           (testing "Happy path"
+                    (is (= '(cond (case> (= :x :y)) (do (one) (two)) (case> (= :x :x)) (three))
+                           (body->sexpr
+                            (transform-sexprs
+                             '(<<switch :x (case> :y) (one) (two) (case> :x) (three)))))))
+
+           (testing "Unification"
+                    (is
+                     (=
+                      '(let
+                        [*x nil
+                         _
+                         (cond
+                          (case> (= :x :y))
+                          (let [*x (identity 1)] {*x *x})
+                          (case> (= :x :x))
+                          (let [*x (identity 2)] {*x *x}))])
+                      (body->sexpr
+                       (transform-sexprs
+                        '(<<switch
+                          :x
+                          (case> :y)
+                          (identity 1 :> *x)
+                          (case> :x)
+                          (identity 2 :> *x)))))))
+
+           (with-testing-context
+            "Arity check on (case> ...)"
              (body->sexpr
               (transform-sexprs
-               '(<<switch :x (case> :y) (one) (two) (case> :x) (three)))))))
-
-    (testing "Unification"
-      (is
-       (=
-        '(let
-          [*x nil
-           _
-           (cond
-            (case> (= :x :y))
-            (let [*x (identity 1)] {*x *x})
-            (case> (= :x :x))
-            (let [*x (identity 2)] {*x *x}))])
-        (body->sexpr
-         (transform-sexprs
-          '(<<switch
-            :x
-            (case> :y)
-            (identity 1 :> *x)
-            (case> :x)
-            (identity 2 :> *x)))))))
-
-    (with-testing-context
-     "Arity check on (case> ...)"
-     (body->sexpr
-      (transform-sexprs
-       '(<<switch :x (case> :x :y) (one) (two) (case> true) (three))))
-     (is (= err/syntax-error-case>-arity
-            (-> utils/*ctx*
-                :findings
-                deref
-                first
-                :message))))))
+               '(<<switch :x (case> :x :y) (one) (two) (case> true) (three))))
+             (is (= err/syntax-error-case>-arity
+                    (-> utils/*ctx*
+                        :findings
+                        deref
+                        first
+                        :message))))))
 
 (deftest <<cond-test
   ;; Test <<cond construct transformation with default> and unification
   ;; Contract: transforms <<cond to cond with case> and default> clauses
 
   (testing "<<cond"
-    (testing "Happy path"
-      (is
-       (=
-        '(cond
-          (case> false)
-          (do
-            (pr 1)
-            (pr (two)))
-          (case> true)
-          (three))
-        (body->sexpr
-         (transform-sexprs
-          '(<<cond
-            (case> false)
-            (pr 1)
-            (pr (two))
-            (case> true)
-            (three)))))))
+           (testing "Happy path"
+                    (is
+                     (=
+                      '(cond
+                        (case> false)
+                        (do
+                         (pr 1)
+                         (pr (two)))
+                        (case> true)
+                        (three))
+                      (body->sexpr
+                       (transform-sexprs
+                        '(<<cond
+                          (case> false)
+                          (pr 1)
+                          (pr (two))
+                          (case> true)
+                          (three)))))))
 
-    (testing "default>"
-      (is
-       (= '(cond
-            (case> false)
-            (do
-              (pr 1)
-              (pr (two)))
-            (default>)
-            (three))
-          (body->sexpr
-           (transform-sexprs
-            '(<<cond
-              (case> false)
-              (pr 1)
-              (pr (two))
-              (default>)
-              (three)))))))
+           (testing "default>"
+                    (is
+                     (= '(cond
+                          (case> false)
+                          (do
+                           (pr 1)
+                           (pr (two)))
+                          (default>)
+                          (three))
+                        (body->sexpr
+                         (transform-sexprs
+                          '(<<cond
+                            (case> false)
+                            (pr 1)
+                            (pr (two))
+                            (default>)
+                            (three)))))))
 
+           (testing "Unification"
+                    (is
+                     (=
+                      '(let
+                        [*x nil
+                         _
+                         (cond
+                          (case> false)
+                          (do
+                           (pr 1)
+                           (let [*x (identity 1)] {*x *x}))
+                          (case> true)
+                          (do
+                           (pr 2)
+                           (let [*x (identity 2)] {*x *x})))])
+                      (body->sexpr
+                       (transform-sexprs
+                        '(<<cond
+                          (case> false)
+                          (pr 1)
+                          (identity 1 :> *x)
+                          (case> true)
+                          (pr 2)
+                          (identity 2 :> *x)))))))
 
-    (testing "Unification"
-      (is
-       (=
-        '(let
-          [*x nil
-           _
-           (cond
-            (case> false)
-            (do
-              (pr 1)
-              (let [*x (identity 1)] {*x *x}))
-            (case> true)
-            (do
-              (pr 2)
-              (let [*x (identity 2)] {*x *x})))])
-        (body->sexpr
-         (transform-sexprs
-          '(<<cond
-            (case> false)
-            (pr 1)
-            (identity 1 :> *x)
-            (case> true)
-            (pr 2)
-            (identity 2 :> *x)))))))
+           (testing "default> unification"
+                    (is
+                     (= '(let
+                          [*x nil
+                           _
+                           (cond
+                            (case> false)
+                            (let [*x (identity 1)] {*x *x})
+                            (default> :unify false)
+                            (pr {*x *x}))]
+                          (pr *x))
+                        (body->sexpr
+                         (transform-sexprs
+                          '(<<cond
+                            (case> false)
+                            (identity 1 :> *x)
+                            (default> :unify false)
+                            (pr))
+                          '(pr *x))))))
 
-    (testing "default> unification"
-      (is
-       (= '(let
-            [*x nil
-             _
-             (cond
-              (case> false)
-              (let [*x (identity 1)] {*x *x})
-              (default> :unify false)
-              (pr {*x *x}))]
-            (pr *x))
-          (body->sexpr
-           (transform-sexprs
-            '(<<cond
-              (case> false)
-              (identity 1 :> *x)
-              (default> :unify false)
-              (pr))
-            '(pr *x))))))
+           (with-testing-context
+            "Arity check on (case> ...)"
+             (body->sexpr
+              (transform-sexprs
+               '(<<cond (case> false true) (one) (two) (case> true) (three))))
+             (is (= err/syntax-error-case>-arity
+                    (-> utils/*ctx*
+                        :findings
+                        deref
+                        first
+                        :message))))
 
-    (with-testing-context
-     "Arity check on (case> ...)"
-     (body->sexpr
-      (transform-sexprs
-       '(<<cond (case> false true) (one) (two) (case> true) (three))))
-     (is (= err/syntax-error-case>-arity
-            (-> utils/*ctx*
-                :findings
-                deref
-                first
-                :message))))
-
-    (testing "Make sure the `do` doesn't get trampolined"
-      (is
-       (=
-        '(cond
-          (trampoline case> false)
-          (do
-            (trampoline pr 1)
-            (trampoline pr (trampoline two)))
-          (trampoline case> true)
-          (trampoline three))
-        (api/sexpr
-         (first
-          (transform-sexprs
-           '(<<cond
-             (case> false)
-             (pr 1)
-             (pr (two))
-             (case> true)
-             (three))))))))))
+           (testing "Make sure the `do` doesn't get trampolined"
+                    (is
+                     (=
+                      '(cond
+                        (trampoline case> false)
+                        (do
+                         (trampoline pr 1)
+                         (trampoline pr (trampoline two)))
+                        (trampoline case> true)
+                        (trampoline three))
+                      (api/sexpr
+                       (first
+                        (transform-sexprs
+                         '(<<cond
+                           (case> false)
+                           (pr 1)
+                           (pr (two))
+                           (case> true)
+                           (three))))))))))
 
 (deftest <<sources-test
   ;; Test <<sources construct for both streaming and microbatch patterns
   ;; Contract: transforms <<sources into fn with source> bindings
 
   (testing "<<sources"
-    (testing "Streaming sources"
-      (is
-       (=
-        '(fn
-          [*depot]
-          (let
-           [*k (source> *depot)]
-           (+compound $$p {*k (+count)})))
-        (body->sexpr
-         (transform-sexprs
-          '(<<sources
-            s
-            (source> *depot :> *k)
-            (+compound $$p {*k (+count)}))))))
+           (testing "Streaming sources"
+                    (is
+                     (=
+                      '(fn
+                        [*depot]
+                        (let
+                         [*k (source> *depot)]
+                         (+compound $$p {*k (+count)})))
+                      (body->sexpr
+                       (transform-sexprs
+                        '(<<sources
+                          s
+                          (source> *depot :> *k)
+                          (+compound $$p {*k (+count)}))))))
 
-      (is
-       (=
-        '(fn
-          [*depot *depot-2]
-          (let
-           [[*k *v] (source> *depot {:retry-mode :individual})]
-           (pr [*k *v])
-           (+compound $$p {*k (+vec-agg *v)}))
-          (let
-           [*k (source> *depot-2)]
-           (pr *k)
-           (+compound $$p {*k (+count)})))
-        (body->sexpr
-         (transform-sexprs
-          '(<<sources
-            s
-            (source> *depot {:retry-mode :individual} :> [*k *v])
-            (pr [*k *v])
-            (+compound $$p {*k (+vec-agg *v)})
-            (source> *depot-2 :> *k)
-            (pr *k)
-            (+compound $$p {*k (+count)})))))))
+                    (is
+                     (=
+                      '(fn
+                        [*depot *depot-2]
+                        (let
+                         [[*k *v] (source> *depot {:retry-mode :individual})]
+                         (pr [*k *v])
+                         (+compound $$p {*k (+vec-agg *v)}))
+                        (let
+                         [*k (source> *depot-2)]
+                         (pr *k)
+                         (+compound $$p {*k (+count)})))
+                      (body->sexpr
+                       (transform-sexprs
+                        '(<<sources
+                          s
+                          (source> *depot {:retry-mode :individual} :> [*k *v])
+                          (pr [*k *v])
+                          (+compound $$p {*k (+vec-agg *v)})
+                          (source> *depot-2 :> *k)
+                          (pr *k)
+                          (+compound $$p {*k (+count)})))))))
 
-    (testing "Microbatch sources"
-      (is
-       (=
-        '(fn
-          [*depot]
-          (let
-           [*k (source> *depot)]
-           (do
-             (inc *k)
-             (let
-              [*k (identity *k)]
-              (+compound $$p {*k (+count)})))))
-        (body->sexpr
-         (transform-sexprs
-          '(<<sources
-            s
-            (source> *depot :> *k)
-            (inc *k :> *k)
-            (+compound $$p {*k (+count)}))))))
+           (testing "Microbatch sources"
+                    (is
+                     (=
+                      '(fn
+                        [*depot]
+                        (let
+                         [*k (source> *depot)]
+                         (do
+                          (inc *k)
+                          (let
+                           [*k (identity *k)]
+                           (+compound $$p {*k (+count)})))))
+                      (body->sexpr
+                       (transform-sexprs
+                        '(<<sources
+                          s
+                          (source> *depot :> *k)
+                          (inc *k :> *k)
+                          (+compound $$p {*k (+count)}))))))
 
-      (is
-       (=
-        '(fn
-          [*depot *depot-2]
-          (let
-           [%microbatch (source> *depot)]
-           (let
-            [[*k *v] (%microbatch)]
-            (pr [*k *v])
-            (+compound $$p {*k (+vec-agg *v)})))
-          (let
-           [%microbatch (source> *depot-2)]
-           (let
-            [*k (%microbatch)]
-            (pr *k)
-            (+compound $$p {*k (+count)}))))
-        (body->sexpr
-         (transform-sexprs
-          '(<<sources
-            s
-            (source> *depot :> %microbatch)
-            (%microbatch :> [*k *v])
-            (pr [*k *v])
-            (+compound $$p {*k (+vec-agg *v)})
-            (source> *depot-2 :> %microbatch)
-            (%microbatch :> *k)
-            (pr *k)
-            (+compound $$p {*k (+count)})))))))
+                    (is
+                     (=
+                      '(fn
+                        [*depot *depot-2]
+                        (let
+                         [%microbatch (source> *depot)]
+                         (let
+                          [[*k *v] (%microbatch)]
+                          (pr [*k *v])
+                          (+compound $$p {*k (+vec-agg *v)})))
+                        (let
+                         [%microbatch (source> *depot-2)]
+                         (let
+                          [*k (%microbatch)]
+                          (pr *k)
+                          (+compound $$p {*k (+count)}))))
+                      (body->sexpr
+                       (transform-sexprs
+                        '(<<sources
+                          s
+                          (source> *depot :> %microbatch)
+                          (%microbatch :> [*k *v])
+                          (pr [*k *v])
+                          (+compound $$p {*k (+vec-agg *v)})
+                          (source> *depot-2 :> %microbatch)
+                          (%microbatch :> *k)
+                          (pr *k)
+                          (+compound $$p {*k (+count)})))))))
 
-    (with-testing-context
-     "Errors"
-     (transform-sexprs
-      '(<<sources
-        s
-        (source> *depot-1 *depot-2 *depot-3 :> *k)
-        (+compound $$p {*k (+count)})))
+           (with-testing-context
+            "Errors"
+             (transform-sexprs
+              '(<<sources
+                s
+                (source> *depot-1 *depot-2 *depot-3 :> *k)
+                (+compound $$p {*k (+count)})))
 
-     (is (= err/syntax-error-source>-arity
-            (-> utils/*ctx*
-                :findings
-                deref
-                first
-                :message))))))
+             (is (= err/syntax-error-source>-arity
+                    (-> utils/*ctx*
+                        :findings
+                        deref
+                        first
+                        :message))))))
 
 (deftest <<subsource-test
   ;; Test <<subsource construct for tagged union type handling
   ;; Contract: transforms <<subsource into case with type-based dispatch
 
   (testing "<<subsource"
-    (is
-     (=
-      '(case
-        (type *data)
-        (case> A)
-        (do (let [{:keys [*a]} (case> A)] (prn *a)))
-        (case> B)
-        (do (let [{:keys [*b]} (case> B)] (prn *b))))
-      (body->sexpr
-       (transform-sexprs
-        '(<<subsource
-          *data
-          (case> A :> {:keys [*a]})
-          (prn *a)
+           (is
+            (=
+             '(case
+               (type *data)
+               (case> A)
+               (do (let [{:keys [*a]} (case> A)] (prn *a)))
+               (case> B)
+               (do (let [{:keys [*b]} (case> B)] (prn *b))))
+             (body->sexpr
+              (transform-sexprs
+               '(<<subsource
+                 *data
+                 (case> A :> {:keys [*a]})
+                 (prn *a)
 
-          (case> B :> {:keys [*b]})
-          (prn *b))))))
+                 (case> B :> {:keys [*b]})
+                 (prn *b))))))
 
-    (is
-     (=
-      '(let
-        [*a nil
-         _
-         (case
-          (type *data)
-          (case> A)
-          (do (let [{:keys [*a]} (case> A)] (prn *a {*a *a})))
-          (case> B)
-          (do (let [{:keys [*a]} (case> B)] (prn *a {*a *a}))))]
-        (prn *a))
-      (body->sexpr
-       (transform-sexprs
-        '(<<subsource
-          *data
-          (case> A :> {:keys [*a]})
-          (prn *a)
+           (is
+            (=
+             '(let
+               [*a nil
+                _
+                (case
+                 (type *data)
+                 (case> A)
+                 (do (let [{:keys [*a]} (case> A)] (prn *a {*a *a})))
+                 (case> B)
+                 (do (let [{:keys [*a]} (case> B)] (prn *a {*a *a}))))]
+               (prn *a))
+             (body->sexpr
+              (transform-sexprs
+               '(<<subsource
+                 *data
+                 (case> A :> {:keys [*a]})
+                 (prn *a)
 
-          (case> B :> {:keys [*a]})
-          (prn *a))
-        '(prn *a)))))))
+                 (case> B :> {:keys [*a]})
+                 (prn *a))
+               '(prn *a)))))))

--- a/test/com/rpl/rama_hooks/demo_gallery_test.clj
+++ b/test/com/rpl/rama_hooks/demo_gallery_test.clj
@@ -1,164 +1,164 @@
 (ns com.rpl.rama-hooks.demo-gallery-test
-  "Tests for real-world Rama modules from the demo gallery.
+    "Tests for real-world Rama modules from the demo gallery.
   Verifies that complete, production-style modules transform correctly."
-  (:require
-   [clojure.test :refer [deftest is]]
-   [com.rpl.rama-hooks :as rama]
-   [com.rpl.test-helpers :refer [sexpr->node node->sexpr]]))
+    (:require
+     [clojure.test :refer [deftest is]]
+     [com.rpl.rama-hooks :as rama]
+     [com.rpl.test-helpers :refer [sexpr->node node->sexpr]]))
 
 (def bank-transfer-module-code
-  '(defmodule
-    BankTransferModule
-    [setup topologies]
-    (declare-depot setup *transfer-depot (hash-by :from-user-id))
-    (declare-depot setup *deposit-depot (hash-by :user-id))
-    (let
-     [mb (microbatch-topology topologies "banking")]
-     (declare-pstate mb $$funds {Long Long})
-     (declare-pstate
-      mb
-      $$outgoing-transfers
-      {Long (map-schema
-             String                 ; transfer-id
-             (fixed-keys-schema
-              {:to-user-id Long
-               :amt        Long
-               :success?   Boolean})
-             {:subindex? true})})
-     (declare-pstate
-      mb
-      $$incoming-transfers
-      {Long (map-schema
-             String                 ; transfer-id
-             (fixed-keys-schema
-              {:from-user-id Long
-               :amt          Long
-               :success?     Boolean})
-             {:subindex? true})})
-     (<<sources
-      mb
-     (source> *transfer-depot :> %microbatch)
-      (%microbatch :> {:keys [*transfer-id *from-user-id *to-user-id *amt]})
-      (local-select> [(keypath *from-user-id) (nil->val 0)] $$funds :> *funds)
-      (>= *funds *amt :> *success?)
-      (<<if
-       *success?
-       (<<ramafn
-        %deduct
-        [*curr]
-        (:> (- *curr *amt)))
-       (local-transform> [(keypath *from-user-id) (term %deduct)] $$funds))
-      (local-transform>
-       [(keypath *from-user-id *transfer-id)
-        (termval
-         {:to-user-id *to-user-id
-          :amt        *amt
-          :success?   *success?})]
-       $$outgoing-transfers)
-      (|hash *to-user-id)
-      (<<if
-       *success?
-       (+compound $$funds {*to-user-id (aggs/+sum *amt)}))
-      (local-transform>
-       [(keypath *to-user-id *transfer-id)
-        (termval
-         {:from-user-id *from-user-id
-          :amt          *amt
-          :success?     *success?})]
-       $$incoming-transfers)
-     (source> *deposit-depot :> %microbatch)
-      (%microbatch :> {:keys [*user-id *amt]})
-      (+compound $$funds {*user-id (aggs/+sum *amt)})))))
+     '(defmodule
+       BankTransferModule
+       [setup topologies]
+       (declare-depot setup *transfer-depot (hash-by :from-user-id))
+       (declare-depot setup *deposit-depot (hash-by :user-id))
+       (let
+        [mb (microbatch-topology topologies "banking")]
+        (declare-pstate mb $$funds {Long Long})
+        (declare-pstate
+         mb
+         $$outgoing-transfers
+         {Long (map-schema
+                String                 ; transfer-id
+                (fixed-keys-schema
+                 {:to-user-id Long
+                  :amt        Long
+                  :success?   Boolean})
+                {:subindex? true})})
+        (declare-pstate
+         mb
+         $$incoming-transfers
+         {Long (map-schema
+                String                 ; transfer-id
+                (fixed-keys-schema
+                 {:from-user-id Long
+                  :amt          Long
+                  :success?     Boolean})
+                {:subindex? true})})
+        (<<sources
+         mb
+         (source> *transfer-depot :> %microbatch)
+         (%microbatch :> {:keys [*transfer-id *from-user-id *to-user-id *amt]})
+         (local-select> [(keypath *from-user-id) (nil->val 0)] $$funds :> *funds)
+         (>= *funds *amt :> *success?)
+         (<<if
+          *success?
+          (<<ramafn
+           %deduct
+           [*curr]
+           (:> (- *curr *amt)))
+          (local-transform> [(keypath *from-user-id) (term %deduct)] $$funds))
+         (local-transform>
+          [(keypath *from-user-id *transfer-id)
+           (termval
+            {:to-user-id *to-user-id
+             :amt        *amt
+             :success?   *success?})]
+          $$outgoing-transfers)
+         (|hash *to-user-id)
+         (<<if
+          *success?
+          (+compound $$funds {*to-user-id (aggs/+sum *amt)}))
+         (local-transform>
+          [(keypath *to-user-id *transfer-id)
+           (termval
+            {:from-user-id *from-user-id
+             :amt          *amt
+             :success?     *success?})]
+          $$incoming-transfers)
+         (source> *deposit-depot :> %microbatch)
+         (%microbatch :> {:keys [*user-id *amt]})
+         (+compound $$funds {*user-id (aggs/+sum *amt)})))))
 
 (def bank-transfer-module-transformed-code
-  '(defn
-    BankTransferModule
-    [setup topologies]
-    (let
-     [*transfer-depot (declare-depot setup (hash-by :from-user-id))]
-     (pr *transfer-depot)
-     (let
-      [*deposit-depot (declare-depot setup (hash-by :user-id))]
-      (pr *deposit-depot)
-      (let
-       [mb (microbatch-topology topologies "banking")]
+     '(defn
+       BankTransferModule
+       [setup topologies]
        (let
-        [$$funds (declare-pstate mb {Long Long})]
-        (pr $$funds)
+        [*transfer-depot (declare-depot setup (hash-by :from-user-id))]
+        (pr *transfer-depot)
         (let
-         [$$outgoing-transfers
-          (declare-pstate
-           mb
-           {Long (map-schema
-                  String ; transfer-id
-                  (fixed-keys-schema
-                   {:to-user-id Long
-                    :amt        Long
-                    :success?   Boolean})
-                  {:subindex? true})})]
-         (pr $$outgoing-transfers)
+         [*deposit-depot (declare-depot setup (hash-by :user-id))]
+         (pr *deposit-depot)
          (let
-          [$$incoming-transfers
-           (declare-pstate
-            mb
-            {Long (map-schema
-                   String     ; transfer-id
-                   (fixed-keys-schema
-                    {:from-user-id Long
-                     :amt          Long
-                     :success?     Boolean})
-                   {:subindex? true})})]
-          (pr $$incoming-transfers)
-          (fn
-           []
+          [mb (microbatch-topology topologies "banking")]
+          (let
+           [$$funds (declare-pstate mb {Long Long})]
+           (pr $$funds)
            (let
-            [%microbatch (source> *transfer-depot)]
+            [$$outgoing-transfers
+             (declare-pstate
+              mb
+              {Long (map-schema
+                     String ; transfer-id
+                     (fixed-keys-schema
+                      {:to-user-id Long
+                       :amt        Long
+                       :success?   Boolean})
+                     {:subindex? true})})]
+            (pr $$outgoing-transfers)
             (let
-             [{:keys [*transfer-id *from-user-id *to-user-id *amt]}
-              (%microbatch)]
-             (let
-              [*funds
-               (local-select>
-                [(keypath *from-user-id) (nil->val 0)]
-                $$funds)]
+             [$$incoming-transfers
+              (declare-pstate
+               mb
+               {Long (map-schema
+                      String     ; transfer-id
+                      (fixed-keys-schema
+                       {:from-user-id Long
+                        :amt          Long
+                        :success?     Boolean})
+                      {:subindex? true})})]
+             (pr $$incoming-transfers)
+             (fn
+              []
               (let
-               [*success? (>= *funds *amt)]
-               (when
-                *success?
-                (letfn
-                 [(%deduct [*curr] (:> (- *curr *amt)))]
-                 (local-transform>
-                  [(keypath *from-user-id)
-                   (term %deduct)]
-                  $$funds)))
+               [%microbatch (source> *transfer-depot)]
+               (let
+                [{:keys [*transfer-id *from-user-id *to-user-id *amt]}
+                 (%microbatch)]
+                (let
+                 [*funds
+                  (local-select>
+                   [(keypath *from-user-id) (nil->val 0)]
+                   $$funds)]
+                 (let
+                  [*success? (>= *funds *amt)]
+                  (when
+                   *success?
+                   (letfn
+                    [(%deduct [*curr] (:> (- *curr *amt)))]
+                    (local-transform>
+                     [(keypath *from-user-id)
+                      (term %deduct)]
+                     $$funds)))
 
-               (local-transform>
-                [(keypath *from-user-id *transfer-id)
-                 (termval
-                  {:to-user-id *to-user-id
-                   :amt        *amt
-                   :success?   *success?})]
-                $$outgoing-transfers)
-               (|hash *to-user-id)
-               (when
-                *success?
+                  (local-transform>
+                   [(keypath *from-user-id *transfer-id)
+                    (termval
+                     {:to-user-id *to-user-id
+                      :amt        *amt
+                      :success?   *success?})]
+                   $$outgoing-transfers)
+                  (|hash *to-user-id)
+                  (when
+                   *success?
+                   (+compound
+                    $$funds
+                    {*to-user-id (aggs/+sum *amt)}))
+                  (local-transform>
+                   [(keypath *to-user-id *transfer-id)
+                    (termval
+                     {:from-user-id *from-user-id
+                      :amt          *amt
+                      :success?     *success?})]
+                   $$incoming-transfers)))))
+              (let
+               [%microbatch (source> *deposit-depot)]
+               (let
+                [{:keys [*user-id *amt]} (%microbatch)]
                 (+compound
                  $$funds
-                 {*to-user-id (aggs/+sum *amt)}))
-               (local-transform>
-                [(keypath *to-user-id *transfer-id)
-                 (termval
-                  {:from-user-id *from-user-id
-                   :amt          *amt
-                   :success?     *success?})]
-                $$incoming-transfers)))))
-           (let
-            [%microbatch (source> *deposit-depot)]
-            (let
-             [{:keys [*user-id *amt]} (%microbatch)]
-             (+compound
-              $$funds
-              {*user-id (aggs/+sum *amt)}))))))))))))
+                 {*user-id (aggs/+sum *amt)}))))))))))))
 
 (deftest demo-gallery-bank-transfer-module-test
   ;; Tests transformation of a bank transfer module with:
@@ -174,135 +174,135 @@
            (sexpr->node bank-transfer-module-code))))))
 
 (def profile-gallery-module-code
-  '(defmodule
-    ProfileModule
-    [setup topologies]
-    (declare-depot setup *registration-depot (hash-by :username))
-    (declare-depot setup *profile-edits-depot (hash-by :user-id))
-    (let
-     [s (stream-topology topologies "profiles")
-      id-gen (ModuleUniqueIdPState. "$$id")]
-     (declare-pstate
-      s
-      $$username->registration
-      {String ; username
-       (fixed-keys-schema
-        {:user-id Long
-         :uuid    String})})
-     (declare-pstate
-      s
-      $$profiles
-      {Long ; user ID
-       (fixed-keys-schema
-        {:username      String
-         :pwd-hash      String
-         :display-name  String
-         :height-inches Long})})
-     (.declarePState id-gen s)
-     (<<sources
-      s
-     (source> *registration-depot :> {:keys [*uuid *username *pwd-hash]})
-      (local-select>
-       (keypath *username)
-       $$username->registration
-       :>
-       {*curr-uuid :uuid :as *curr-info})
-      (<<if
-       (or>
-        (nil? *curr-info)
-        (= *curr-uuid *uuid))
-       (java-macro! (.genId id-gen "*user-id"))
-       (local-transform>
-        [(keypath *username)
-         (multi-path
-          [:user-id (termval *user-id)]
-          [:uuid (termval *uuid)])]
-        $$username->registration)
-       (|hash *user-id)
-       (local-transform>
-        [(keypath *user-id)
-         (multi-path
-          [:username (termval *username)]
-          [:pwd-hash (termval *pwd-hash)])]
-        $$profiles))
-     (source> *profile-edits-depot :> {:keys [*user-id *edits]})
-      (explode *edits :> {:keys [*field *value]})
-      (local-transform>
-       [(keypath *user-id *field) (termval *value)]
-       $$profiles)))))
+     '(defmodule
+       ProfileModule
+       [setup topologies]
+       (declare-depot setup *registration-depot (hash-by :username))
+       (declare-depot setup *profile-edits-depot (hash-by :user-id))
+       (let
+        [s (stream-topology topologies "profiles")
+         id-gen (ModuleUniqueIdPState. "$$id")]
+        (declare-pstate
+         s
+         $$username->registration
+         {String ; username
+          (fixed-keys-schema
+           {:user-id Long
+            :uuid    String})})
+        (declare-pstate
+         s
+         $$profiles
+         {Long ; user ID
+          (fixed-keys-schema
+           {:username      String
+            :pwd-hash      String
+            :display-name  String
+            :height-inches Long})})
+        (.declarePState id-gen s)
+        (<<sources
+         s
+         (source> *registration-depot :> {:keys [*uuid *username *pwd-hash]})
+         (local-select>
+          (keypath *username)
+          $$username->registration
+          :>
+          {*curr-uuid :uuid :as *curr-info})
+         (<<if
+          (or>
+           (nil? *curr-info)
+           (= *curr-uuid *uuid))
+          (java-macro! (.genId id-gen "*user-id"))
+          (local-transform>
+           [(keypath *username)
+            (multi-path
+             [:user-id (termval *user-id)]
+             [:uuid (termval *uuid)])]
+           $$username->registration)
+          (|hash *user-id)
+          (local-transform>
+           [(keypath *user-id)
+            (multi-path
+             [:username (termval *username)]
+             [:pwd-hash (termval *pwd-hash)])]
+           $$profiles))
+         (source> *profile-edits-depot :> {:keys [*user-id *edits]})
+         (explode *edits :> {:keys [*field *value]})
+         (local-transform>
+          [(keypath *user-id *field) (termval *value)]
+          $$profiles)))))
 
 (def profile-gallery-module-transformed-code
-  '(defn
-    ProfileModule
-    [setup topologies]
-    (let
-     [*registration-depot (declare-depot setup (hash-by :username))]
-     (pr *registration-depot)
-     (let
-      [*profile-edits-depot (declare-depot setup (hash-by :user-id))]
-      (pr *profile-edits-depot)
-      (let
-       [s (stream-topology topologies "profiles")
-        id-gen (ModuleUniqueIdPState. "$$id")]
+     '(defn
+       ProfileModule
+       [setup topologies]
        (let
-        [$$username->registration
-         (declare-pstate
-          s
-          {String
-           (fixed-keys-schema
-            {:user-id Long
-             :uuid    String})})]
-        (pr $$username->registration)
+        [*registration-depot (declare-depot setup (hash-by :username))]
+        (pr *registration-depot)
         (let
-         [$$profiles
-          (declare-pstate
-           s
-           {Long (fixed-keys-schema
-                  {:username      String
-                   :pwd-hash      String
-                   :display-name  String
-                   :height-inches Long})})]
-         (pr $$profiles)
-         (.declarePState id-gen s)
-         (fn
-          []
+         [*profile-edits-depot (declare-depot setup (hash-by :user-id))]
+         (pr *profile-edits-depot)
+         (let
+          [s (stream-topology topologies "profiles")
+           id-gen (ModuleUniqueIdPState. "$$id")]
           (let
-           [{:keys [*uuid *username *pwd-hash]}
-            (source> *registration-depot)]
+           [$$username->registration
+            (declare-pstate
+             s
+             {String
+              (fixed-keys-schema
+               {:user-id Long
+                :uuid    String})})]
+           (pr $$username->registration)
            (let
-            [{:as *curr-info *curr-uuid :uuid}
-             (local-select>
-              (keypath *username)
-              $$username->registration)]
-            (when
-             (or>
-              (nil? *curr-info)
-              (= *curr-uuid *uuid))
+            [$$profiles
+             (declare-pstate
+              s
+              {Long (fixed-keys-schema
+                     {:username      String
+                      :pwd-hash      String
+                      :display-name  String
+                      :height-inches Long})})]
+            (pr $$profiles)
+            (.declarePState id-gen s)
+            (fn
+             []
              (let
-              [_ (pr) [*user-id] []]
-              (pr [*user-id])
-              (.genId id-gen "*user-id")
-              (local-transform>
-               [(keypath *username)
-                (multi-path
-                 [:user-id (termval *user-id)]
-                 [:uuid (termval *uuid)])]
-               $$username->registration)
-              (|hash *user-id)
-              (local-transform>
-               [(keypath *user-id)
-                (multi-path
-                 [:username (termval *username)]
-                 [:pwd-hash (termval *pwd-hash)])]
-               $$profiles)))))
-          (let
-           [{:keys [*user-id *edits]}
-            (source> *profile-edits-depot)]
-           (let
-            [{:keys [*field *value]} (explode *edits)]
-            (local-transform>
-             [(keypath *user-id *field) (termval *value)]
-             $$profiles)))))))))))
+              [{:keys [*uuid *username *pwd-hash]}
+               (source> *registration-depot)]
+              (let
+               [{:as *curr-info *curr-uuid :uuid}
+                (local-select>
+                 (keypath *username)
+                 $$username->registration)]
+               (when
+                (or>
+                 (nil? *curr-info)
+                 (= *curr-uuid *uuid))
+                (let
+                 [_ (pr) [*user-id] []]
+                 (pr [*user-id])
+                 (.genId id-gen "*user-id")
+                 (local-transform>
+                  [(keypath *username)
+                   (multi-path
+                    [:user-id (termval *user-id)]
+                    [:uuid (termval *uuid)])]
+                  $$username->registration)
+                 (|hash *user-id)
+                 (local-transform>
+                  [(keypath *user-id)
+                   (multi-path
+                    [:username (termval *username)]
+                    [:pwd-hash (termval *pwd-hash)])]
+                  $$profiles)))))
+             (let
+              [{:keys [*user-id *edits]}
+               (source> *profile-edits-depot)]
+              (let
+               [{:keys [*field *value]} (explode *edits)]
+               (local-transform>
+                [(keypath *user-id *field) (termval *value)]
+                $$profiles)))))))))))
 
 (deftest demo-gallery-profile-module-test
   ;; Tests transformation of a user profile module with:
@@ -318,108 +318,108 @@
            (sexpr->node profile-gallery-module-code))))))
 
 (def time-series-module-code
-  '(defmodule
-    TimeSeriesModule
-    [setup topologies]
-    (declare-depot setup *render-latency-depot (hash-by :url))
-    (let
-     [mb (microbatch-topology topologies "timeseries")]
-     (declare-pstate
-      mb
-      $$window-stats
-      {String                ; url
-       {clojure.lang.Keyword ; granularity
-        (map-schema
-         Long                ; bucket
-         WindowStats
-         {:subindex? true})}})
-     (<<sources
-      mb
-     (source> *render-latency-depot :> %microbatch)
-      (%microbatch :> {:keys [*url *render-millis *timestamp-millis]})
-      (single-window-stat *render-millis :> *single-stat)
-      (emit-index-granularities *timestamp-millis :> *granularity *bucket)
-      (+compound
-       $$window-stats
-       {*url
-        {*granularity
-         {*bucket (+combine-measurements *single-stat)}}}))
-     (<<query-topology
-      topologies
-      "get-stats-for-minute-range"
-      [*url *start-bucket *end-bucket :> *stats]
-      (|hash *url)
-      (explode
-       (query-granularities :m *start-bucket *end-bucket)
-       :> [*granularity *gstart *gend])
-      (local-select>
-       [(keypath *url *granularity)
-        (sorted-map-range *gstart *gend)
-        MAP-VALS]
-       $$window-stats
-       :> *bucket-stat)
-      (|origin)
-      (+combine-measurements *bucket-stat :> *stats)))))
-
-(def time-series-module-transformed-code
-  '(defn
-    TimeSeriesModule
-    [setup topologies]
-    (let
-     [*render-latency-depot (declare-depot setup (hash-by :url))]
-     (pr *render-latency-depot)
-     (let
-      [mb (microbatch-topology topologies "timeseries")]
-      (let
-       [$$window-stats
+     '(defmodule
+       TimeSeriesModule
+       [setup topologies]
+       (declare-depot setup *render-latency-depot (hash-by :url))
+       (let
+        [mb (microbatch-topology topologies "timeseries")]
         (declare-pstate
          mb
-         {String              ; url
+         $$window-stats
+         {String                ; url
           {clojure.lang.Keyword ; granularity
            (map-schema
-            Long              ; bucket
+            Long                ; bucket
             WindowStats
-            {:subindex? true})}})]
-       (pr $$window-stats)
-       (fn
-        []
+            {:subindex? true})}})
+        (<<sources
+         mb
+         (source> *render-latency-depot :> %microbatch)
+         (%microbatch :> {:keys [*url *render-millis *timestamp-millis]})
+         (single-window-stat *render-millis :> *single-stat)
+         (emit-index-granularities *timestamp-millis :> *granularity *bucket)
+         (+compound
+          $$window-stats
+          {*url
+           {*granularity
+            {*bucket (+combine-measurements *single-stat)}}}))
+        (<<query-topology
+         topologies
+         "get-stats-for-minute-range"
+         [*url *start-bucket *end-bucket :> *stats]
+         (|hash *url)
+         (explode
+          (query-granularities :m *start-bucket *end-bucket)
+          :> [*granularity *gstart *gend])
+         (local-select>
+          [(keypath *url *granularity)
+           (sorted-map-range *gstart *gend)
+           MAP-VALS]
+          $$window-stats
+          :> *bucket-stat)
+         (|origin)
+         (+combine-measurements *bucket-stat :> *stats)))))
+
+(def time-series-module-transformed-code
+     '(defn
+       TimeSeriesModule
+       [setup topologies]
+       (let
+        [*render-latency-depot (declare-depot setup (hash-by :url))]
+        (pr *render-latency-depot)
         (let
-         [%microbatch (source> *render-latency-depot)]
+         [mb (microbatch-topology topologies "timeseries")]
          (let
-          [{:keys [*url *render-millis *timestamp-millis]} (%microbatch)]
-          (let
-           [*single-stat (single-window-stat *render-millis)]
+          [$$window-stats
+           (declare-pstate
+            mb
+            {String              ; url
+             {clojure.lang.Keyword ; granularity
+              (map-schema
+               Long              ; bucket
+               WindowStats
+               {:subindex? true})}})]
+          (pr $$window-stats)
+          (fn
+           []
            (let
-            [[*granularity *bucket]
-             (emit-index-granularities *timestamp-millis)]
-            (+compound
-             $$window-stats
-             {*url
-              {*granularity
-               {*bucket (+combine-measurements
-                         *single-stat)}}}))))))
-       (fn
-        get-stats-for-minute-range
-        [*url *start-bucket *end-bucket]
-        (|hash *url)
-        (let
-         [[*granularity *gstart *gend]
-          (explode
-           (query-granularities
-            :m
-            *start-bucket
-            *end-bucket))]
-         (let
-          [*bucket-stat
-           (local-select>
-            [(keypath *url *granularity)
-             (sorted-map-range *gstart *gend)
-             MAP-VALS]
-            $$window-stats)]
-          (|origin)
-          (let
-           [*stats (+combine-measurements *bucket-stat)]
-           [*stats])))))))))
+            [%microbatch (source> *render-latency-depot)]
+            (let
+             [{:keys [*url *render-millis *timestamp-millis]} (%microbatch)]
+             (let
+              [*single-stat (single-window-stat *render-millis)]
+              (let
+               [[*granularity *bucket]
+                (emit-index-granularities *timestamp-millis)]
+               (+compound
+                $$window-stats
+                {*url
+                 {*granularity
+                  {*bucket (+combine-measurements
+                            *single-stat)}}}))))))
+          (fn
+           get-stats-for-minute-range
+           [*url *start-bucket *end-bucket]
+           (|hash *url)
+           (let
+            [[*granularity *gstart *gend]
+             (explode
+              (query-granularities
+               :m
+               *start-bucket
+               *end-bucket))]
+            (let
+             [*bucket-stat
+              (local-select>
+               [(keypath *url *granularity)
+                (sorted-map-range *gstart *gend)
+                MAP-VALS]
+               $$window-stats)]
+             (|origin)
+             (let
+              [*stats (+combine-measurements *bucket-stat)]
+              [*stats])))))))))
 
 (deftest demo-gallery-time-seties-module-test
   ;; Tests transformation of a time series module with:
@@ -435,81 +435,81 @@
            (sexpr->node time-series-module-code))))))
 
 (def top-users-module-code
-  '(defmodule
-    TopUsersModule
-    [setup topologies]
-    (declare-depot setup *purchase-depot (hash-by :user-id))
-    (let
-     [mb (microbatch-topology topologies "topusers")]
-     (declare-pstate mb $$user-total-spend {Long Long})
-     (declare-pstate mb $$top-spending-users java.util.List {:global? true})
-     (<<sources
-      mb
-     (source> *purchase-depot :> %microbatch)
-      (<<batch
-       (<<if
-        true
-        (identity 1 :> *x)
-       (else>)
-        (identity 2 :> *x))
-       (pr *x)
-       (loop<-
-        [*x [1 2 3] :> *ret])
-       (user-spend-subbatch %microbatch :> *user-id *total-spend-cents)
-       (vector *user-id *total-spend-cents :> *tuple)
-       (|global)
-       (+top-monotonic
-        [TOP-AMOUNT]
-        $$top-spending-users
-        *tuple
-        :+options
-        {:id-fn       first
-         :sort-val-fn last}))))))
+     '(defmodule
+       TopUsersModule
+       [setup topologies]
+       (declare-depot setup *purchase-depot (hash-by :user-id))
+       (let
+        [mb (microbatch-topology topologies "topusers")]
+        (declare-pstate mb $$user-total-spend {Long Long})
+        (declare-pstate mb $$top-spending-users java.util.List {:global? true})
+        (<<sources
+         mb
+         (source> *purchase-depot :> %microbatch)
+         (<<batch
+          (<<if
+           true
+           (identity 1 :> *x)
+           (else>)
+           (identity 2 :> *x))
+          (pr *x)
+          (loop<-
+           [*x [1 2 3] :> *ret])
+          (user-spend-subbatch %microbatch :> *user-id *total-spend-cents)
+          (vector *user-id *total-spend-cents :> *tuple)
+          (|global)
+          (+top-monotonic
+           [TOP-AMOUNT]
+           $$top-spending-users
+           *tuple
+           :+options
+           {:id-fn       first
+            :sort-val-fn last}))))))
 
 (def top-users-module-transformed-code
-  '(defn
-    TopUsersModule
-    [setup topologies]
-    (let
-     [*purchase-depot (declare-depot setup (hash-by :user-id))]
-     (pr *purchase-depot)
-     (let
-      [mb (microbatch-topology topologies "topusers")]
-      (let
-       [$$user-total-spend (declare-pstate mb {Long Long})]
-       (pr $$user-total-spend)
+     '(defn
+       TopUsersModule
+       [setup topologies]
        (let
-        [$$top-spending-users
-         (declare-pstate mb java.util.List {:global? true})]
-        (pr $$top-spending-users)
-        (fn
-         []
+        [*purchase-depot (declare-depot setup (hash-by :user-id))]
+        (pr *purchase-depot)
+        (let
+         [mb (microbatch-topology topologies "topusers")]
          (let
-          [%microbatch (source> *purchase-depot)]
-          (<<batch
-           (let
-            [*x nil
-             _
-             (if
-              true
-              (let [*x (identity 1)] {*x *x})
-              (let [*x (identity 2)] {*x *x}))]
-            (pr *x)
+          [$$user-total-spend (declare-pstate mb {Long Long})]
+          (pr $$user-total-spend)
+          (let
+           [$$top-spending-users
+            (declare-pstate mb java.util.List {:global? true})]
+           (pr $$top-spending-users)
+           (fn
+            []
             (let
-             [[*ret] (let [*x [1 2 3]])]
-             (let
-              [[*user-id *total-spend-cents]
-               (user-spend-subbatch %microbatch)]
+             [%microbatch (source> *purchase-depot)]
+             (<<batch
               (let
-               [*tuple (vector *user-id *total-spend-cents)]
-               (|global)
-               (+top-monotonic
-                [TOP-AMOUNT]
-                $$top-spending-users
-                *tuple
-                :+options
-                {:id-fn       first
-                 :sort-val-fn last}))))))))))))))
+               [*x nil
+                _
+                (if
+                 true
+                 (let [*x (identity 1)] {*x *x})
+                 (let [*x (identity 2)] {*x *x}))]
+               (pr *x)
+               (let
+                [[*ret] (let [*x [1 2 3]])]
+                (let
+                 [[*user-id *total-spend-cents]
+                  (user-spend-subbatch %microbatch)]
+                 (let
+                  [*tuple (vector *user-id *total-spend-cents)]
+                  (|global)
+                  (+top-monotonic
+                   [TOP-AMOUNT]
+                   $$top-spending-users
+                   *tuple
+                   :+options
+                   {:id-fn       first
+                    :sort-val-fn last}))))))))))))))
 
 (deftest demo-gallery-top-users-module-test
   ;; Tests transformation of a top users module with:

--- a/test/com/rpl/rama_hooks/interop_test.clj
+++ b/test/com/rpl/rama_hooks/interop_test.clj
@@ -1,7 +1,7 @@
 (ns com.rpl.rama-hooks.interop-test
-  (:require
-   [clojure.test :refer [deftest is testing]]
-   [com.rpl.test-helpers :refer [body->sexpr transform-sexprs]]))
+    (:require
+     [clojure.test :refer [deftest is testing]]
+     [com.rpl.test-helpers :refer [body->sexpr transform-sexprs]]))
 
 ;;; Test interactions between Rama dataflow and Clojure/Java code.
 ;;; Covers clj! for escaping to Clojure evaluation, java-block<- for
@@ -10,108 +10,104 @@
 
 (deftest clj!-test
   (testing "clj!"
-    (testing "preserves nested Clojure code unchanged"
-      (is (= '(clj! (let [m {:a 1 :b 2}]
-                      (prn (:a m))))
-             (body->sexpr
-              (transform-sexprs
-               '(clj! (let [m {:a 1 :b 2}]
-                        (prn (:a m)))))))))
+           (testing "preserves nested Clojure code unchanged"
+                    (is (= '(clj! (let [m {:a 1 :b 2}]
+                                       (prn (:a m))))
+                           (body->sexpr
+                            (transform-sexprs
+                             '(clj! (let [m {:a 1 :b 2}]
+                                         (prn (:a m)))))))))
 
-    (testing "allows referencing dataflow variables"
-      (is (= '(let [*a (identity 1)]
-                (let [*b (identity 2)]
-                  (let [*c (+ 3 (clj!
-                                 (let [m {:a *a :b *b}]
-                                   (reduce (fn [a v] (+ a v)) (vals m)))))]
-                    (prn *c))
-                  ))
-             (body->sexpr
-              (transform-sexprs
-               '(identity 1 :> *a)
-               '(identity 2 :> *b)
-               '(+ 3 (clj! (let [m {:a *a :b *b}]
-                             (reduce (fn [a v] (+ a v)) (vals m))))
-                   :> *c)
-               '(prn *c)
-               )))))))
+           (testing "allows referencing dataflow variables"
+                    (is (= '(let [*a (identity 1)]
+                                 (let [*b (identity 2)]
+                                      (let [*c (+ 3 (clj!
+                                                     (let [m {:a *a :b *b}]
+                                                          (reduce (fn [a v] (+ a v)) (vals m)))))]
+                                           (prn *c))))
+                           (body->sexpr
+                            (transform-sexprs
+                             '(identity 1 :> *a)
+                             '(identity 2 :> *b)
+                             '(+ 3 (clj! (let [m {:a *a :b *b}]
+                                              (reduce (fn [a v] (+ a v)) (vals m))))
+                                 :> *c)
+                             '(prn *c))))))))
 
 (deftest java-block<--test
   (testing "java-block<-"
-    (testing "enables dataflow inside java-macro! context"
-      (is
-       (=
-        '(let
-          [_ (pr) [*aVar] []]
-          (pr [*aVar])
-          (.aMacro
-           "*aVar"
-           (java-block<-
-            (let
-             [*bVar (identity 1)]
-             (let [*c (+ *aVar *bVar)]))))
-          (pr "*aVar")
-         )
-        (body->sexpr
-         (transform-sexprs
-          '(java-macro!
-            (.aMacro
-             "*aVar"
-             (java-block<-
-              (identity 1 :> *bVar)
-              (+ *aVar *bVar :> *c))))
-          '(pr "*aVar"))))))))
+           (testing "enables dataflow inside java-macro! context"
+                    (is
+                     (=
+                      '(let
+                        [_ (pr) [*aVar] []]
+                        (pr [*aVar])
+                        (.aMacro
+                         "*aVar"
+                         (java-block<-
+                          (let
+                           [*bVar (identity 1)]
+                           (let [*c (+ *aVar *bVar)]))))
+                        (pr "*aVar"))
+                      (body->sexpr
+                       (transform-sexprs
+                        '(java-macro!
+                          (.aMacro
+                           "*aVar"
+                           (java-block<-
+                            (identity 1 :> *bVar)
+                            (+ *aVar *bVar :> *c))))
+                        '(pr "*aVar"))))))))
 
 (deftest java-macro!-test
   (testing "java-macro!"
-    (testing "converts variable references to strings"
-      (is
-       (= '(let
-            [_ (pr) [*user-id] []]
-            (pr [*user-id])
-            (.genid id-gen "*user-id"))
-          (body->sexpr
-           (transform-sexprs
-            '(java-macro! (.genid id-gen "*user-id")))))))
+           (testing "converts variable references to strings"
+                    (is
+                     (= '(let
+                          [_ (pr) [*user-id] []]
+                          (pr [*user-id])
+                          (.genid id-gen "*user-id"))
+                        (body->sexpr
+                         (transform-sexprs
+                          '(java-macro! (.genid id-gen "*user-id")))))))
 
-    (testing "handles multiple variable types"
-      (is
-       (= '(let
-            [_ (pr) [*a !b %c] []]
-            (pr [*a !b %c])
-            (.genid id-gen "*a" "!b" "%c"))
-          (body->sexpr
-           (transform-sexprs
-            '(java-macro! (.genid id-gen "*a" "!b" "%c")))))))
+           (testing "handles multiple variable types"
+                    (is
+                     (= '(let
+                          [_ (pr) [*a !b %c] []]
+                          (pr [*a !b %c])
+                          (.genid id-gen "*a" "!b" "%c"))
+                        (body->sexpr
+                         (transform-sexprs
+                          '(java-macro! (.genid id-gen "*a" "!b" "%c")))))))
 
-    (testing "handles invalid variable names"
-      (is (= '(let [_ (pr) [] []] (pr []) (.genid id-gen "*a b"))
-             (body->sexpr
-              (transform-sexprs
-               '(java-macro! (.genid id-gen "*a b")))))))
+           (testing "handles invalid variable names"
+                    (is (= '(let [_ (pr) [] []] (pr []) (.genid id-gen "*a b"))
+                           (body->sexpr
+                            (transform-sexprs
+                             '(java-macro! (.genid id-gen "*a b")))))))
 
-    (testing "preserves regular strings"
-      (is (= '(let [_ (pr) [] []] (pr []) (.genid id-gen "something"))
-             (body->sexpr
-              (transform-sexprs '(java-macro! (.genid id-gen "something")))))))
+           (testing "preserves regular strings"
+                    (is (= '(let [_ (pr) [] []] (pr []) (.genid id-gen "something"))
+                           (body->sexpr
+                            (transform-sexprs '(java-macro! (.genid id-gen "something")))))))
 
-    (testing "integrates with dataflow transformations"
-      (is
-       (=
-        '(let
-          [*a (identity 1)]
-          (let
-           [*b (identity 2)]
-           (let
-            [_ (pr *b *a) [*c] []]
-            (pr [*c])
-            (.sum "*a" "*b" "*c")
-            (pr *c)
-           )))
-        (body->sexpr
-         (transform-sexprs
-          '(identity 1 :> *a)
-          '(identity 2 :> *b)
-          '(java-macro!
-            (.sum "*a" "*b" "*c"))
-          '(pr *c))))))))
+           (testing "integrates with dataflow transformations"
+                    (is
+                     (=
+                      '(let
+                        [*a (identity 1)]
+                        (let
+                         [*b (identity 2)]
+                         (let
+                          [_ (pr *b *a) [*c] []]
+                          (pr [*c])
+                          (.sum "*a" "*b" "*c")
+                          (pr *c))))
+                      (body->sexpr
+                       (transform-sexprs
+                        '(identity 1 :> *a)
+                        '(identity 2 :> *b)
+                        '(java-macro!
+                          (.sum "*a" "*b" "*c"))
+                        '(pr *c))))))))

--- a/test/com/rpl/rama_hooks/module_code_test.clj
+++ b/test/com/rpl/rama_hooks/module_code_test.clj
@@ -1,182 +1,182 @@
 (ns com.rpl.rama-hooks.module-code-test
-  (:require
-   [clj-kondo.hooks-api :as api]
-   [clojure.test :refer [deftest is testing]]
-   [com.rpl.errors :as err]
-   [com.rpl.rama-hooks :as rama]
-   [com.rpl.test-helpers :refer [get-error-messages
-                                  sexpr->node
-                                  node->sexpr
-                                  transform-module-sexprs
-                                  ->sexpr
-                                  with-testing-context]]))
+    (:require
+     [clj-kondo.hooks-api :as api]
+     [clojure.test :refer [deftest is testing]]
+     [com.rpl.errors :as err]
+     [com.rpl.rama-hooks :as rama]
+     [com.rpl.test-helpers :refer [get-error-messages
+                                   sexpr->node
+                                   node->sexpr
+                                   transform-module-sexprs
+                                   ->sexpr
+                                   with-testing-context]]))
 
 (deftest module-hook-test
   ;; Test module-hook transformation of module code (declare-depot, declare-pstate)
   ;; Contracts: transforms linear module forms into nested let expressions
   (testing "module-hook"
-    (testing "Basic expressions within a module"
-      (is (= '(let
-               [*depot (declare-depot setup (hash-by :x))]
-               (pr *depot))
-             (api/sexpr
-              (first
-               (rama/transform-module-form
-                (->sexpr '(declare-depot setup *depot (hash-by :x)))
-                nil
-                #{})))))
-      (is
-       (= '(let
-            [*depot (declare-depot setup (hash-by :x))]
-            (pr *depot)
-            (let
-             [*depot-2 (declare-depot setup (hash-by :y))]
-             (pr *depot-2)
-             (pr *depot-2)))
-          (api/sexpr (first
-                      (transform-module-sexprs
-                       '(declare-depot setup *depot (hash-by :x))
-                       '(declare-depot setup *depot-2 (hash-by :y))
-                       '(pr *depot-2)))))))
+           (testing "Basic expressions within a module"
+                    (is (= '(let
+                             [*depot (declare-depot setup (hash-by :x))]
+                             (pr *depot))
+                           (api/sexpr
+                            (first
+                             (rama/transform-module-form
+                              (->sexpr '(declare-depot setup *depot (hash-by :x)))
+                              nil
+                              #{})))))
+                    (is
+                     (= '(let
+                          [*depot (declare-depot setup (hash-by :x))]
+                          (pr *depot)
+                          (let
+                           [*depot-2 (declare-depot setup (hash-by :y))]
+                           (pr *depot-2)
+                           (pr *depot-2)))
+                        (api/sexpr (first
+                                    (transform-module-sexprs
+                                     '(declare-depot setup *depot (hash-by :x))
+                                     '(declare-depot setup *depot-2 (hash-by :y))
+                                     '(pr *depot-2)))))))
 
-    (testing "Basic anonymous module definitions"
-      (let [module-def
-            '(module
-              [setup topologies]
-              (declare-depot setup *transfer-depot (hash-by :x))
-              (let
-               [mb (microbatch-topology topologies "banking")]
-               (declare-pstate mb $$funds {Long Long})))]
-        (is
-         (=
-          '(fn
-            [setup topologies]
-            (let
-             [*transfer-depot (declare-depot setup (hash-by :x))]
-             (pr *transfer-depot)
-             (let
-              [mb (microbatch-topology topologies "banking")]
-              (let
-               [$$funds (declare-pstate mb {Long Long})]
-               (pr $$funds)))))
-          (node->sexpr
-           (rama/module-hook
-            (sexpr->node module-def)))))))
+           (testing "Basic anonymous module definitions"
+                    (let [module-def
+                          '(module
+                            [setup topologies]
+                            (declare-depot setup *transfer-depot (hash-by :x))
+                            (let
+                             [mb (microbatch-topology topologies "banking")]
+                             (declare-pstate mb $$funds {Long Long})))]
+                         (is
+                          (=
+                           '(fn
+                             [setup topologies]
+                             (let
+                              [*transfer-depot (declare-depot setup (hash-by :x))]
+                              (pr *transfer-depot)
+                              (let
+                               [mb (microbatch-topology topologies "banking")]
+                               (let
+                                [$$funds (declare-pstate mb {Long Long})]
+                                (pr $$funds)))))
+                           (node->sexpr
+                            (rama/module-hook
+                             (sexpr->node module-def)))))))
 
-    (with-testing-context
-     "Errors if the module input vectors is missing, or isn't a vector"
-     (rama/module-hook
-      (sexpr->node '(module)))
+           (with-testing-context
+            "Errors if the module input vectors is missing, or isn't a vector"
+             (rama/module-hook
+              (sexpr->node '(module)))
 
-     (rama/module-hook
-      (sexpr->node '(module ())))
+             (rama/module-hook
+              (sexpr->node '(module ())))
 
-     (rama/module-hook
-      (sexpr->node '(module {:module-name "xyz"} ())))
+             (rama/module-hook
+              (sexpr->node '(module {:module-name "xyz"} ())))
 
-     (rama/module-hook
-      (sexpr->node '(module {:module-name "xyz"})))
+             (rama/module-hook
+              (sexpr->node '(module {:module-name "xyz"})))
 
-     (is (= [err/syntax-error-missing-input-vector
-             err/syntax-error-missing-input-vector
-             err/syntax-error-missing-input-vector
-             err/syntax-error-missing-input-vector]
-            (get-error-messages))))))
+             (is (= [err/syntax-error-missing-input-vector
+                     err/syntax-error-missing-input-vector
+                     err/syntax-error-missing-input-vector
+                     err/syntax-error-missing-input-vector]
+                    (get-error-messages))))))
 
 (deftest defmodule-hook-test
   ;; Test defmodule-hook transformation of module definitions
   ;; Contracts: transforms defmodule into defn with nested let expressions
   (testing "defmodule-hook"
-    (testing "Basic defmodule definitions"
-      (let [module-def
-            '(defmodule
-              MyModule
-              [setup topologies]
-              (declare-depot setup *transfer-depot (hash-by :x))
-              (let
-               [mb (microbatch-topology topologies "banking")]
-               (declare-pstate mb $$funds {Long Long})))]
-        (is
-         (=
-          '(defn
-            MyModule
-            [setup topologies]
-            (let
-             [*transfer-depot (declare-depot setup (hash-by :x))]
-             (pr *transfer-depot)
-             (let
-              [mb (microbatch-topology topologies "banking")]
-              (let
-               [$$funds (declare-pstate mb {Long Long})]
-               (pr $$funds)))))
-          (node->sexpr
-           (rama/defmodule-hook
-            (sexpr->node module-def)))))))
+           (testing "Basic defmodule definitions"
+                    (let [module-def
+                          '(defmodule
+                            MyModule
+                            [setup topologies]
+                            (declare-depot setup *transfer-depot (hash-by :x))
+                            (let
+                             [mb (microbatch-topology topologies "banking")]
+                             (declare-pstate mb $$funds {Long Long})))]
+                         (is
+                          (=
+                           '(defn
+                             MyModule
+                             [setup topologies]
+                             (let
+                              [*transfer-depot (declare-depot setup (hash-by :x))]
+                              (pr *transfer-depot)
+                              (let
+                               [mb (microbatch-topology topologies "banking")]
+                               (let
+                                [$$funds (declare-pstate mb {Long Long})]
+                                (pr $$funds)))))
+                           (node->sexpr
+                            (rama/defmodule-hook
+                             (sexpr->node module-def)))))))
 
-    (testing "Full defmodule definitions"
-      (is
-       (=
-        '(defn
-          RestAPIIntegrationModule
-          [setup topologies]
-          (let
-           [*depot (declare-depot setup (hash-by identity))]
-           (pr *depot)
-           (let
-            [*depot-2 (declare-depot setup (hash-by identity))]
-            (pr *depot-2)
-            (let
-             [s (stream-topology topologies "s")]
-             (let
-              [$$p1 (declare-pstate s {Object Object})]
-              (pr $$p1)
-              (let
-               [$$p2 (declare-pstate s {Object Long})]
-               (pr $$p2)
-               (fn
-                []
-                (let
-                 [[*k *v] (source> *depot)]
-                 (+compound $$p {*k (+vec-agg *v)}))
-                (let
-                 [*key (source> *depot-2)]
-                 (+compound $$p {*key (+count)})))))))))
-        (node->sexpr
-         (rama/defmodule-hook
-          (sexpr->node '(defmodule
-                         RestAPIIntegrationModule
-                         [setup topologies]
-                         (declare-depot setup *depot (hash-by identity))
-                         (declare-depot setup *depot-2 (hash-by identity))
+           (testing "Full defmodule definitions"
+                    (is
+                     (=
+                      '(defn
+                        RestAPIIntegrationModule
+                        [setup topologies]
+                        (let
+                         [*depot (declare-depot setup (hash-by identity))]
+                         (pr *depot)
                          (let
-                          [s (stream-topology topologies "s")]
-                          (declare-pstate s $$p1 {Object Object})
-                          (declare-pstate s $$p2 {Object Long})
-                          (<<sources
-                           s
-                          (source> *depot :> [*k *v])
-                           (+compound $$p {*k (+vec-agg *v)})
-                          (source> *depot-2 :> *key)
-                           (+compound $$p {*key (+count)}))))))))))
+                          [*depot-2 (declare-depot setup (hash-by identity))]
+                          (pr *depot-2)
+                          (let
+                           [s (stream-topology topologies "s")]
+                           (let
+                            [$$p1 (declare-pstate s {Object Object})]
+                            (pr $$p1)
+                            (let
+                             [$$p2 (declare-pstate s {Object Long})]
+                             (pr $$p2)
+                             (fn
+                              []
+                              (let
+                               [[*k *v] (source> *depot)]
+                               (+compound $$p {*k (+vec-agg *v)}))
+                              (let
+                               [*key (source> *depot-2)]
+                               (+compound $$p {*key (+count)})))))))))
+                      (node->sexpr
+                       (rama/defmodule-hook
+                        (sexpr->node '(defmodule
+                                       RestAPIIntegrationModule
+                                       [setup topologies]
+                                       (declare-depot setup *depot (hash-by identity))
+                                       (declare-depot setup *depot-2 (hash-by identity))
+                                       (let
+                                        [s (stream-topology topologies "s")]
+                                        (declare-pstate s $$p1 {Object Object})
+                                        (declare-pstate s $$p2 {Object Long})
+                                        (<<sources
+                                         s
+                                         (source> *depot :> [*k *v])
+                                         (+compound $$p {*k (+vec-agg *v)})
+                                         (source> *depot-2 :> *key)
+                                         (+compound $$p {*key (+count)}))))))))))
 
-    (with-testing-context
-     "Errors if the module name or input vectors are missing, or don't have the correct type"
-     (rama/defmodule-hook
-      (sexpr->node '(defmodule)))
+           (with-testing-context
+            "Errors if the module name or input vectors are missing, or don't have the correct type"
+             (rama/defmodule-hook
+              (sexpr->node '(defmodule)))
 
-     (rama/defmodule-hook
-      (sexpr->node '(defmodule 123)))
+             (rama/defmodule-hook
+              (sexpr->node '(defmodule 123)))
 
-     (rama/defmodule-hook
-      (sexpr->node '(defmodule 123 [])))
+             (rama/defmodule-hook
+              (sexpr->node '(defmodule 123 [])))
 
-     (rama/defmodule-hook
-      (sexpr->node '(defmodule symbol (xyz))))
+             (rama/defmodule-hook
+              (sexpr->node '(defmodule symbol (xyz))))
 
-     (is (= [err/syntax-error-missing-def-name
-             err/syntax-error-missing-input-vector
-             err/syntax-error-missing-def-name
-             err/syntax-error-missing-input-vector
-             err/syntax-error-missing-def-name
-             err/syntax-error-missing-input-vector]
-            (get-error-messages))))))
+             (is (= [err/syntax-error-missing-def-name
+                     err/syntax-error-missing-input-vector
+                     err/syntax-error-missing-def-name
+                     err/syntax-error-missing-input-vector
+                     err/syntax-error-missing-def-name
+                     err/syntax-error-missing-input-vector]
+                    (get-error-messages))))))

--- a/test/com/rpl/rama_hooks/top_level_forms_test.clj
+++ b/test/com/rpl/rama_hooks/top_level_forms_test.clj
@@ -1,28 +1,28 @@
 (ns com.rpl.rama-hooks.top-level-forms-test
-  "Tests for top-level form transformations like defbasicsegmacro, 
+    "Tests for top-level form transformations like defbasicsegmacro, 
    defbasicblocksegmacro, and top-level block hooks."
-  (:require
-   [clj-kondo.impl.utils :as utils]
-   [clojure.test :refer [deftest is testing]]
-   [com.rpl.errors :as err]
-   [com.rpl.rama-hooks :as rama]
-   [com.rpl.test-helpers :refer [node->sexpr sexpr->node with-testing-context]]))
+    (:require
+     [clj-kondo.impl.utils :as utils]
+     [clojure.test :refer [deftest is testing]]
+     [com.rpl.errors :as err]
+     [com.rpl.rama-hooks :as rama]
+     [com.rpl.test-helpers :refer [node->sexpr sexpr->node with-testing-context]]))
 
 (deftest defbasicsegmacro-test
   (is
    (=
     '(defn traverse>
-       [path target out-var]
-       (let [out-var (or out-var (gen-anyvar))]
-         [sc/traverse>* target (seg# path> path) :> out-var]))
+           [path target out-var]
+           (let [out-var (or out-var (gen-anyvar))]
+                [sc/traverse>* target (seg# path> path) :> out-var]))
     (node->sexpr
      (rama/defsegmacro-hook
-       (sexpr->node
-        '(defbasicsegmacro
-           traverse>
-           [path target :> out-var]
-           (let [out-var (or out-var (gen-anyvar))]
-             [sc/traverse>* target (seg# path> path) :> out-var]))))))))
+      (sexpr->node
+       '(defbasicsegmacro
+         traverse>
+         [path target :> out-var]
+         (let [out-var (or out-var (gen-anyvar))]
+              [sc/traverse>* target (seg# path> path) :> out-var]))))))))
 
 (deftest defbasicblocksegmacro-test
   (is
@@ -43,54 +43,54 @@
 
 (deftest top-level-block-hook-test
   (let [result '(do (let [*x (identity 1)]))]
-    (is (= result
-           (node->sexpr
-            (rama/top-level-block-hook
-             (sexpr->node '(?<- (identity 1 :> *x)))))))
-    (is (= result
-           (node->sexpr
-            (rama/top-level-block-hook
-             (sexpr->node '(<<do (identity 1 :> *x)))))))
-    (is (= result
-           (node->sexpr
-            (rama/top-level-block-hook
-             (sexpr->node '(<<branch (identity 1 :> *x)))))))
-    (is (= result
-           (node->sexpr
-            (rama/top-level-block-hook
-             (sexpr->node '(<<atomic (identity 1 :> *x)))))))))
+       (is (= result
+              (node->sexpr
+               (rama/top-level-block-hook
+                (sexpr->node '(?<- (identity 1 :> *x)))))))
+       (is (= result
+              (node->sexpr
+               (rama/top-level-block-hook
+                (sexpr->node '(<<do (identity 1 :> *x)))))))
+       (is (= result
+              (node->sexpr
+               (rama/top-level-block-hook
+                (sexpr->node '(<<branch (identity 1 :> *x)))))))
+       (is (= result
+              (node->sexpr
+               (rama/top-level-block-hook
+                (sexpr->node '(<<atomic (identity 1 :> *x)))))))))
 
 (deftest defn-like-hook-test
   ;; Tests transformation of deframaop and deframafn forms to defn.
   ;; Contracts: both forms support optional docstrings and transform correctly.
   (let [f (fn [form]
-            (node->sexpr
-             (rama/deframaop-hook
-              (sexpr->node form))))]
-    (testing "deframaop without docstring"
-      (is (= '(defn f [] (:> nil)) (f '(deframaop f [] (:>))))))
-    
-    (testing "deframaop with docstring"
-      (is (= '(defn f "A function" [] (:> nil))
-             (f '(deframaop f "A function" [] (:>))))))
-    
-    (testing "deframafn without docstring"
-      (is (= '(defn f [*a] (:> nil)) (f '(deframafn f [*a] (:>))))))
-    
-    (testing "deframafn with docstring"
-      (is (= '(defn f "Takes a value" [*a] (:> nil))
-             (f '(deframafn f "Takes a value" [*a] (:>))))))
-    
-    (testing "deframaop with multi-line docstring"
-      (is (= '(defn f "Line 1\nLine 2" [] (:> nil))
-             (f '(deframaop f "Line 1\nLine 2" [] (:>))))))
-    
-    (with-testing-context
-      "malformed deframaop with docstring but no input vector"
-      (rama/deframaop-hook (sexpr->node '(deframaop f "A doc")))
-      (is (= err/syntax-error-missing-input-vector
-             (-> utils/*ctx*
-                 :findings
-                 deref
-                 first
-                 :message))))))
+              (node->sexpr
+               (rama/deframaop-hook
+                (sexpr->node form))))]
+       (testing "deframaop without docstring"
+                (is (= '(defn f [] (:> nil)) (f '(deframaop f [] (:>))))))
+
+       (testing "deframaop with docstring"
+                (is (= '(defn f "A function" [] (:> nil))
+                       (f '(deframaop f "A function" [] (:>))))))
+
+       (testing "deframafn without docstring"
+                (is (= '(defn f [*a] (:> nil)) (f '(deframafn f [*a] (:>))))))
+
+       (testing "deframafn with docstring"
+                (is (= '(defn f "Takes a value" [*a] (:> nil))
+                       (f '(deframafn f "Takes a value" [*a] (:>))))))
+
+       (testing "deframaop with multi-line docstring"
+                (is (= '(defn f "Line 1\nLine 2" [] (:> nil))
+                       (f '(deframaop f "Line 1\nLine 2" [] (:>))))))
+
+       (with-testing-context
+        "malformed deframaop with docstring but no input vector"
+         (rama/deframaop-hook (sexpr->node '(deframaop f "A doc")))
+         (is (= err/syntax-error-missing-input-vector
+                (-> utils/*ctx*
+                    :findings
+                    deref
+                    first
+                    :message))))))

--- a/test/com/rpl/rama_hooks/validation_test.clj
+++ b/test/com/rpl/rama_hooks/validation_test.clj
@@ -1,141 +1,141 @@
 (ns com.rpl.rama-hooks.validation-test
-  (:require
-   [clj-kondo.impl.utils :as utils]
-   [clojure.test :refer [deftest is testing]]
-   [com.rpl.errors :as err]
-   [com.rpl.rama-hooks :as rama]
-   [com.rpl.test-helpers :refer [body->sexpr
-                                  node->sexpr
-                                  sexpr->node
-                                  transform-sexprs
-                                  with-testing-context]]))
+    (:require
+     [clj-kondo.impl.utils :as utils]
+     [clojure.test :refer [deftest is testing]]
+     [com.rpl.errors :as err]
+     [com.rpl.rama-hooks :as rama]
+     [com.rpl.test-helpers :refer [body->sexpr
+                                   node->sexpr
+                                   sexpr->node
+                                   transform-sexprs
+                                   with-testing-context]]))
 
 (deftest keywords-as-fns-are-illegal-in-dataflow-test
   (with-testing-context
-      "Can't have fn appear in foreign-select contexts"
+   "Can't have fn appear in foreign-select contexts"
 
     (binding [rama/*context* :dataflow]
 
-      (body->sexpr
-       (transform-sexprs
-        '(identity {:a 1 :b 2} :> *map)
-        '(:a *map :> *val)))
+             (body->sexpr
+              (transform-sexprs
+               '(identity {:a 1 :b 2} :> *map)
+               '(:a *map :> *val)))
 
-      (is (= err/syntax-error-keyword-fn-in-dataflow
-             (-> utils/*ctx*
-                 :findings
-                 deref
-                 first
-                 :message))))))
+             (is (= err/syntax-error-keyword-fn-in-dataflow
+                    (-> utils/*ctx*
+                        :findings
+                        deref
+                        first
+                        :message))))))
 
 (deftest lambda-are-illegal-in-multiple-contexts-test
   (with-testing-context
-      "Can't have fn appear in foreign-select contexts"
-      (rama/foreign-select-hook
-       (sexpr->node '(foreign-select [:x (view (fn [x] (inc x)))]
-                                     $$pstate)))
-      (is (= err/syntax-error-lambda-fn-in-foreign-select
-             (-> utils/*ctx*
-                 :findings
-                 deref
-                 first
-                 :message))))
+   "Can't have fn appear in foreign-select contexts"
+    (rama/foreign-select-hook
+     (sexpr->node '(foreign-select [:x (view (fn [x] (inc x)))]
+                                   $$pstate)))
+    (is (= err/syntax-error-lambda-fn-in-foreign-select
+           (-> utils/*ctx*
+               :findings
+               deref
+               first
+               :message))))
 
   (with-testing-context
-      "Can't use fn in dataflow code contexts"
+   "Can't use fn in dataflow code contexts"
     (binding [rama/*context* :dataflow]
-      (body->sexpr
-       (transform-sexprs
-        '(foreign-select [:x (view (fn [x] (inc x)))]
-                         $$pstate)))
-      (is (= (err/syntax-error-illegal-special-form 'fn)
-             (-> utils/*ctx*
-                 :findings
-                 deref
-                 first
-                 :message))))))
+             (body->sexpr
+              (transform-sexprs
+               '(foreign-select [:x (view (fn [x] (inc x)))]
+                                $$pstate)))
+             (is (= (err/syntax-error-illegal-special-form 'fn)
+                    (-> utils/*ctx*
+                        :findings
+                        deref
+                        first
+                        :message))))))
 
 (deftest special-forms-are-illegal-in-dataflow-test
   (binding [rama/*context* :dataflow]
-    (doseq [form rama/illegal-forms]
-      (with-testing-context
-          (str "Can't use " form " in dataflow code.")
+           (doseq [form rama/illegal-forms]
+                  (with-testing-context
+                   (str "Can't use " form " in dataflow code.")
 
-          (body->sexpr
-           (transform-sexprs
-            '(when true? (prn "true"))))
+                    (body->sexpr
+                     (transform-sexprs
+                      '(when true? (prn "true"))))
 
-          (is (= (err/syntax-error-illegal-special-form 'when)
-                 (-> utils/*ctx*
-                     :findings
-                     deref
-                     first
-                     :message)))))))
+                    (is (= (err/syntax-error-illegal-special-form 'when)
+                           (-> utils/*ctx*
+                               :findings
+                               deref
+                               first
+                               :message)))))))
 
 (deftest java-method-calls-and-constructors-are-illegal-in-dataflow-test
   (with-testing-context
-      "Java constructors and method calls are illegal in dataflow code"
+   "Java constructors and method calls are illegal in dataflow code"
 
     (binding [rama/*context* :dataflow]
 
-      (body->sexpr
-       (transform-sexprs
-        '(HashMap. :> *map)
-        '(.set *map :a 1)))
+             (body->sexpr
+              (transform-sexprs
+               '(HashMap. :> *map)
+               '(.set *map :a 1)))
 
-      (is (= [err/syntax-error-java-interop-in-dataflow
-              err/syntax-error-java-interop-in-dataflow]
-             (->> utils/*ctx*
-                 :findings
-                 deref
-                 (mapv :message)))))))
+             (is (= [err/syntax-error-java-interop-in-dataflow
+                     err/syntax-error-java-interop-in-dataflow]
+                    (->> utils/*ctx*
+                         :findings
+                         deref
+                         (mapv :message)))))))
 
 (def bank-transfer-module-with-error-code
-  '(defmodule BankTransferModule
-     [setup topologies]
-     (declare-depot setup *transfer-depot (hash-by :from-user-id))
-     (let [mb (microbatch-topology topologies "banking")]
-       (declare-pstate mb $$funds {Long Long})
-       (<<sources
-        mb
-        (source> *transfer-depot :> %microbatch)
-        (%microbatch :> {:keys [*success? *from-user-id *amt]})
-        (identity {:a 1 :b 2} :> *map)
-        (:a *map :> *a)
-        (<<if
-         *success?
-         (<<ramafn
-          %deduct [*curr]
-          (:> (- *curr *amt)))
-         (local-transform>
-          [(keypath *from-user-id) (term %deduct)] $$funds))))))
+     '(defmodule BankTransferModule
+                 [setup topologies]
+                 (declare-depot setup *transfer-depot (hash-by :from-user-id))
+                 (let [mb (microbatch-topology topologies "banking")]
+                      (declare-pstate mb $$funds {Long Long})
+                      (<<sources
+                       mb
+                       (source> *transfer-depot :> %microbatch)
+                       (%microbatch :> {:keys [*success? *from-user-id *amt]})
+                       (identity {:a 1 :b 2} :> *map)
+                       (:a *map :> *a)
+                       (<<if
+                        *success?
+                        (<<ramafn
+                         %deduct [*curr]
+                         (:> (- *curr *amt)))
+                        (local-transform>
+                         [(keypath *from-user-id) (term %deduct)] $$funds))))))
 
 (def bank-transfer-module-with-error-code-transformed
-  '(defn BankTransferModule
-     [setup topologies]
-     (let [*transfer-depot (declare-depot setup (hash-by :from-user-id))]
-       (pr *transfer-depot)
-       (let [mb (microbatch-topology topologies "banking")]
-         (let [$$funds (declare-pstate mb {Long Long})]
-           (pr $$funds)
-           (fn
-             []
-             (let [%microbatch (source> *transfer-depot)]
-               (let [{:keys [*success? *from-user-id *amt]} (%microbatch)]
-                 (let [*map (identity {:a 1 :b 2})]
-                   (let [*a (:a *map)]
-                     (when *success?
-                       (letfn
-                           [(%deduct [*curr] (:> (- *curr *amt)))]
-                           (local-transform>
-                            [(keypath *from-user-id)
-                             (term %deduct)]
-                            $$funds)))))))))))))
+     '(defn BankTransferModule
+            [setup topologies]
+            (let [*transfer-depot (declare-depot setup (hash-by :from-user-id))]
+                 (pr *transfer-depot)
+                 (let [mb (microbatch-topology topologies "banking")]
+                      (let [$$funds (declare-pstate mb {Long Long})]
+                           (pr $$funds)
+                           (fn
+                            []
+                            (let [%microbatch (source> *transfer-depot)]
+                                 (let [{:keys [*success? *from-user-id *amt]} (%microbatch)]
+                                      (let [*map (identity {:a 1 :b 2})]
+                                           (let [*a (:a *map)]
+                                                (when *success?
+                                                      (letfn
+                                                       [(%deduct [*curr] (:> (- *curr *amt)))]
+                                                       (local-transform>
+                                                        [(keypath *from-user-id)
+                                                         (term %deduct)]
+                                                        $$funds)))))))))))))
 
 (deftest bank-transfer-module-with-errors-test
   (with-testing-context
-      "Should error in multiple places"
-      (is (= bank-transfer-module-with-error-code-transformed
-             (node->sexpr
-              (rama/defmodule-hook
-                (sexpr->node bank-transfer-module-with-error-code)))))))
+   "Should error in multiple places"
+    (is (= bank-transfer-module-with-error-code-transformed
+           (node->sexpr
+            (rama/defmodule-hook
+             (sexpr->node bank-transfer-module-with-error-code)))))))

--- a/test/com/rpl/test_helpers.clj
+++ b/test/com/rpl/test_helpers.clj
@@ -1,74 +1,74 @@
 (ns com.rpl.test-helpers
-  "Shared test utilities for rama-clj-kondo tests."
-  (:require
-   [clj-kondo.hooks-api :as api]
-   [clj-kondo.impl.utils :as utils :refer [parse-string]]
-   [clojure.test :refer [testing]]
-   [com.rpl.rama-hooks :as rama]))
+    "Shared test utilities for rama-clj-kondo tests."
+    (:require
+     [clj-kondo.hooks-api :as api]
+     [clj-kondo.impl.utils :as utils :refer [parse-string]]
+     [clojure.test :refer [testing]]
+     [com.rpl.rama-hooks :as rama]))
 
 (defn get-first-error-message
-  "Returns the message from the first finding in the current test context."
-  []
-  (-> utils/*ctx*
-      :findings
-      deref
-      first
-      :message))
+      "Returns the message from the first finding in the current test context."
+      []
+      (-> utils/*ctx*
+          :findings
+          deref
+          first
+          :message))
 
 (defn get-error-messages
-  "Returns a vector of all finding messages in the current test context."
-  []
-  (->> utils/*ctx*
-       :findings
-       deref
-       (mapv :message)))
+      "Returns a vector of all finding messages in the current test context."
+      []
+      (->> utils/*ctx*
+           :findings
+           deref
+           (mapv :message)))
 
 (defmacro with-testing-context
-  "Creates a testing context with isolated clj-kondo state for findings.
+          "Creates a testing context with isolated clj-kondo state for findings.
   Use this to wrap test assertions that check for linting errors."
-  [test-desc & body]
-  `(testing ~test-desc
-     (binding [utils/*ctx* {:base-lang  :clj
-                            :lang       :clj
-                            :namespaces (atom {:clj {:clj {}}})
-                            :findings   (atom [])
-                            :ignores    (atom {})}]
-       ~@body)))
+          [test-desc & body]
+          `(testing ~test-desc
+                    (binding [utils/*ctx* {:base-lang  :clj
+                                           :lang       :clj
+                                           :namespaces (atom {:clj {:clj {}}})
+                                           :findings   (atom [])
+                                           :ignores    (atom {})}]
+                             ~@body)))
 
 (defn ->sexpr
-  "Converts a Clojure expression to a clj-kondo node by printing and parsing."
-  [expr]
-  (parse-string (prn-str expr)))
+      "Converts a Clojure expression to a clj-kondo node by printing and parsing."
+      [expr]
+      (parse-string (prn-str expr)))
 
 (defn transform-sexprs
-  "Transforms multiple s-expressions using rama/transform-body."
-  [& sexprs]
-  (let [sexprs (mapv ->sexpr sexprs)]
-    (rama/transform-body sexprs)))
+      "Transforms multiple s-expressions using rama/transform-body."
+      [& sexprs]
+      (let [sexprs (mapv ->sexpr sexprs)]
+           (rama/transform-body sexprs)))
 
 (defn transform-module-sexprs
-  "Transforms multiple s-expressions as module body using rama/transform-module-body."
-  [& sexprs]
-  (rama/transform-module-body
-   (mapv ->sexpr sexprs)
-   #{}))
+      "Transforms multiple s-expressions as module body using rama/transform-module-body."
+      [& sexprs]
+      (rama/transform-module-body
+       (mapv ->sexpr sexprs)
+       #{}))
 
 (defn strip-trampoline
-  "Removes all instances of 'trampoline symbols from the s-expression."
-  [sexpr]
-  (rama/remove-instances sexpr #{'trampoline}))
+      "Removes all instances of 'trampoline symbols from the s-expression."
+      [sexpr]
+      (rama/remove-instances sexpr #{'trampoline}))
 
 (defn sexpr->node
-  "Wraps an s-expression in a node map for testing."
-  [x]
-  {:node (->sexpr x)})
+      "Wraps an s-expression in a node map for testing."
+      [x]
+      {:node (->sexpr x)})
 
 (defn node->sexpr
-  "Extracts the s-expression from a node map, stripping trampoline symbols."
-  [x]
-  (strip-trampoline (api/sexpr (:node x))))
+      "Extracts the s-expression from a node map, stripping trampoline symbols."
+      [x]
+      (strip-trampoline (api/sexpr (:node x))))
 
 (defn body->sexpr
-  "Extracts the s-expression from the first item in a sequence, stripping trampoline symbols."
-  [x]
-  (strip-trampoline (api/sexpr (first x))))
+      "Extracts the s-expression from the first item in a sequence, stripping trampoline symbols."
+      [x]
+      (strip-trampoline (api/sexpr (first x))))


### PR DESCRIPTION
## Summary

Add cljfmt to the project with proper configuration, pre-commit hook integration, and perform initial formatting.

## Changes

- Added dev.weavejester/cljfmt 0.15.3 as :cljfmt alias in deps.edn
- Created .cljfmt.edn with custom indentation rules for with-testing-context
- Added install-pre-commit-hook.sh script to automatically format code on commit
- Reformatted all test files using cljfmt

## Commits

- feat: add cljfmt code formatter with pre-commit hook (d94d7ac)