### PR TITLE
feat: add clj-kondo linting with pre-push hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,25 +29,6 @@ Note that if your dependency on Rama is specified under a specific alias or
 profile, you need to make sure to include that in the `clojure` or `lein`
 command. Otherwise the Rama jar won't be on the classpath.
 
-### Git Hooks (Optional)
-
-This project includes scripts to install Git hooks for maintaining code quality:
-
-**Pre-commit hook** - Automatically formats `.clj` and `.edn` files using cljfmt when you commit:
-
-``` sh
-./scripts/install-pre-commit-hook.sh
-```
-
-**Pre-push hook** - Runs clj-kondo linting before pushing to prevent pushing code with warnings or errors:
-
-``` sh
-./scripts/install-pre-push-hook.sh
-```
-
-The pre-push hook will block pushes if clj-kondo finds any issues in the project.
-
-
 ## Roadmap 
 
 There are a number of Rama features that are known to not lint correctly. 
@@ -107,4 +88,24 @@ Since having access to the following forms is important for the transformation
 rules, hooks in the `config.edn` are only defined for top-level forms. 
 Transformation rules for special Rama forms, such as `<<if` or `batch<-` are 
 written as extensions of the `split-form` or `handle-form` methods in 
-`rama_hooks.clj`. 
+`rama_hooks.clj`.
+
+## Development
+
+### Git Hooks
+
+This project includes scripts to install Git hooks for maintaining code quality:
+
+**Pre-commit hook** - Automatically formats `.clj` and `.edn` files using cljfmt when you commit:
+
+``` sh
+./scripts/install-pre-commit-hook.sh
+```
+
+**Pre-push hook** - Runs clj-kondo linting before pushing to prevent pushing code with warnings or errors:
+
+``` sh
+./scripts/install-pre-push-hook.sh
+```
+
+The pre-push hook will block pushes if clj-kondo finds any issues in the project. 

--- a/README.md
+++ b/README.md
@@ -17,17 +17,35 @@ You can get clj-kondo to import the linting rules for Rama by running:
 clj-kondo --lint "$(clojure -Spath)" --copy-configs --skip-lint
 ```
 
-or 
+or
 
 ``` sh
 clj-kondo --lint "$(lein classpath)" --copy-configs --skip-lint
 ```
 
-If you're using leiningen. 
+If you're using leiningen.
 
-Note that if your dependency on Rama is specified under a specific alias or 
-profile, you need to make sure to include that in the `clojure` or `lein` 
+Note that if your dependency on Rama is specified under a specific alias or
+profile, you need to make sure to include that in the `clojure` or `lein`
 command. Otherwise the Rama jar won't be on the classpath.
+
+### Git Hooks (Optional)
+
+This project includes scripts to install Git hooks for maintaining code quality:
+
+**Pre-commit hook** - Automatically formats `.clj` and `.edn` files using cljfmt when you commit:
+
+``` sh
+./scripts/install-pre-commit-hook.sh
+```
+
+**Pre-push hook** - Runs clj-kondo linting before pushing to prevent pushing code with warnings or errors:
+
+``` sh
+./scripts/install-pre-push-hook.sh
+```
+
+The pre-push hook will block pushes if clj-kondo finds any issues in the project.
 
 
 ## Roadmap 

--- a/scripts/install-pre-push-hook.sh
+++ b/scripts/install-pre-push-hook.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Script to install pre-push hook for clj-kondo
+
+set -e
+
+HOOK_FILE=".git/hooks/pre-push"
+
+# Create the pre-push hook
+cat > "$HOOK_FILE" << 'EOF'
+#!/usr/bin/env bash
+# Pre-push hook to run clj-kondo linting
+
+echo "Running clj-kondo linting..."
+
+# Run clj-kondo on exports and tests
+if clj-kondo --lint clj-kondo.exports test; then
+  echo "clj-kondo linting passed"
+  exit 0
+else
+  echo "ERROR: clj-kondo found warnings or errors"
+  echo "Please fix linting issues before pushing"
+  exit 1
+fi
+EOF
+
+# Make the hook executable
+chmod +x "$HOOK_FILE"
+
+echo "Pre-push hook installed at $HOOK_FILE"

--- a/test/com/rpl/rama_hooks/basic_test.clj
+++ b/test/com/rpl/rama_hooks/basic_test.clj
@@ -1,6 +1,7 @@
 (ns com.rpl.rama-hooks.basic-test
     (:require
      [clj-kondo.hooks-api :as api]
+     [clj-kondo.impl.utils :as utils]
      [clojure.test :refer [deftest is testing]]
      [com.rpl.errors :as err]
      [com.rpl.rama-hooks :as rama]
@@ -162,7 +163,7 @@
                          [(keypath *from-user-id) (term %deduct)] $$funds)))))))
 
     (is (= err/syntax-error-keyword-fn-in-dataflow
-           (-> clj-kondo.impl.utils/*ctx*
+           (-> utils/*ctx*
                :findings
                deref
                first

--- a/test/com/rpl/rama_hooks/branching_test.clj
+++ b/test/com/rpl/rama_hooks/branching_test.clj
@@ -4,8 +4,7 @@
      [clj-kondo.impl.utils :as utils]
      [clojure.test :refer [deftest is testing]]
      [com.rpl.errors :as err]
-     [com.rpl.test-helpers :refer [body->sexpr get-error-messages
-                                   get-first-error-message sexpr->node
+     [com.rpl.test-helpers :refer [body->sexpr
                                    transform-sexprs with-testing-context]]))
 
 ;;; Tests for Rama branching constructs: <<if, <<switch, <<cond, <<sources, <<subsource

--- a/test/com/rpl/rama_hooks/validation_test.clj
+++ b/test/com/rpl/rama_hooks/validation_test.clj
@@ -1,7 +1,7 @@
 (ns com.rpl.rama-hooks.validation-test
     (:require
      [clj-kondo.impl.utils :as utils]
-     [clojure.test :refer [deftest is testing]]
+     [clojure.test :refer [deftest is]]
      [com.rpl.errors :as err]
      [com.rpl.rama-hooks :as rama]
      [com.rpl.test-helpers :refer [body->sexpr


### PR DESCRIPTION
## Summary

This PR adds comprehensive clj-kondo linting support with a pre-push Git hook that prevents pushing code with linting issues.

## Implementation

The implementation followed a methodical approach:

1. **Fixed existing clj-kondo warnings** (4 issues in test suite)
   - Added missing import of clj-kondo.impl.utils in basic_test.clj
   - Removed unused refers in branching_test.clj (get-error-messages, get-first-error-message, sexpr->node)
   - Removed unused testing refer in validation_test.clj
   - Removed unused clojure.string import in basic_test.clj

2. **Created pre-push hook infrastructure**
   - Implemented scripts/install-pre-push-hook.sh following the pattern of the existing pre-commit hook
   - Hook runs `clj-kondo --lint clj-kondo.exports test` before each push
   - Returns exit code 1 to block pushes when warnings or errors are found
   - Both install script and generated hook are executable and shellcheck-validated

3. **Updated documentation**
   - Added Git Hooks section to README.md with installation instructions
   - Documents both pre-commit (cljfmt) and pre-push (clj-kondo) hooks
   - Reorganized README to include Development section for hooks

## Commits

- fix: remove unused namespace references in test files
- feat: add pre-push hook for clj-kondo linting
- docs: add Git hooks installation section to README
- docs: move Git hooks section to Development

## Testing

- All clj-kondo linting now passes cleanly on `clj-kondo.exports` and `test` directories
- Pre-push hook successfully blocks pushes when linting issues are present
- Pre-push hook allows pushes when linting is clean
- Both hook install scripts pass shellcheck validation