### PR TITLE
ci: add GitHub Actions workflow for CI checks

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,7 @@
+{:linters {:unresolved-var {:exclude [com.rpl.rama-hooks/illegal-forms
+                                      com.rpl.rama-hooks/*context*
+                                      com.rpl.rama-hooks/foreign-select-hook
+                                      com.rpl.errors/syntax-error-keyword-fn-in-dataflow
+                                      com.rpl.errors/syntax-error-lambda-fn-in-foreign-select
+                                      com.rpl.errors/syntax-error-illegal-special-form
+                                      com.rpl.errors/syntax-error-java-interop-in-dataflow]}}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run clj-kondo linting
         id: clj-kondo
         continue-on-error: true
-        run: clj-kondo --lint .
+        run: clj-kondo --lint . --fail-level warning
 
       - name: Run tests
         id: tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  ci-checks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: deps-${{ hashFiles('deps.edn') }}
+          restore-keys: deps-
+
+      - name: Install Clojure CLI
+        uses: DeLaGuardo/setup-clojure@13.0
+        with:
+          cli: latest
+          clj-kondo: latest
+
+      - name: Run cljfmt check
+        id: cljfmt
+        continue-on-error: true
+        run: clojure -M:cljfmt check
+
+      - name: Run clj-kondo linting
+        id: clj-kondo
+        continue-on-error: true
+        run: clj-kondo --lint .
+
+      - name: Run tests
+        id: tests
+        continue-on-error: true
+        run: clojure -M:test
+
+      - name: Check results
+        if: steps.cljfmt.outcome == 'failure' || steps.clj-kondo.outcome == 'failure' || steps.tests.outcome == 'failure'
+        run: |
+          echo "One or more checks failed:"
+          echo "  cljfmt: ${{ steps.cljfmt.outcome }}"
+          echo "  clj-kondo: ${{ steps.clj-kondo.outcome }}"
+          echo "  tests: ${{ steps.tests.outcome }}"
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Lint and Test
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   ci-checks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
             ~/.m2/repository
             ~/.gitlibs
           key: deps-${{ hashFiles('deps.edn') }}
-          restore-keys: deps-
+          restore-keys: deps-${{ runner.os }}-
 
       - name: Install Clojure CLI
         uses: DeLaGuardo/setup-clojure@13.0


### PR DESCRIPTION
## Summary

Adds GitHub Actions workflow to automate CI checks on PRs and master branch pushes. The workflow runs cljfmt, clj-kondo, and tests, ensuring code quality and correctness.

## Implementation

- Created `.github/workflows/ci.yml` with Java 21 and Clojure CLI setup
- Runs three checks: cljfmt formatting, clj-kondo linting, and test suite
- Uses dependency caching (Maven/Gitlibs) for faster builds
- Includes manual workflow dispatch trigger for on-demand runs
- Added `.clj-kondo/config.edn` to suppress false positive warnings in tests

## Commits

- feat: add GitHub Actions CI workflow
- feat: add explicit fail-level flag to clj-kondo
- refactor: make cache restore-keys OS-specific
- refactor: rename workflow from CI to Lint and Test
- feat: add workflow_dispatch trigger for manual workflow runs
- fix: suppress unresolved var warnings for hook implementation vars