### PR TITLE
Disable unverifiable-pobject linter by default and fix destructuring rebinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,26 @@ Note that if your dependency on Rama is specified under a specific alias or
 profile, you need to make sure to include that in the `clojure` or `lein`
 command. Otherwise the Rama jar won't be on the classpath.
 
-## Roadmap 
+## Optional Linters
+
+### Unverifiable PState references (`:rama-unverifiable-pobject`)
+
+When `$$`-prefixed PState symbols or depot vars are used in standalone
+`<<query-topology` or `<<sources` forms (outside a `defmodule`), the linter
+cannot verify that they were declared in a module scope. This linter emits
+info-level diagnostics for such references.
+
+This linter is **disabled by default** because these references are typically
+valid — they refer to PStates or depots declared elsewhere in the module. To
+enable it, add the following to your project's `.clj-kondo/config.edn`:
+
+``` clojure
+{:linters {:rama-unverifiable-pobject {:level :info}}}
+```
+
+You can also set the level to `:warning` or `:error` if desired.
+
+## Roadmap
 
 There are a number of Rama features that are known to not lint correctly. 
 Since Rama segments get transformed into a graph, reorganizing the code to 

--- a/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
+++ b/clj-kondo.exports/com.rpl/rama/com/rpl/rama_hooks.clj
@@ -1006,7 +1006,14 @@
                     ;; such, this call to `trampoline` is inserted to ensure
                     ;; that the editor is able to provide this functionality.
                                      expr         (cons (api/token-node 'trampoline) expr)
-                                     new-bindings (if rebinds
+                                     ;; Destructuring output (single vector/map node)
+                                     ;; must use the original node as the binding form,
+                                     ;; even when all vars are rebinds.
+                                     destructuring? (and (= 1 (count out))
+                                                         (let [o (first out)]
+                                                              (or (api/vector-node? o)
+                                                                  (api/map-node? o))))
+                                     new-bindings (if (and rebinds (not destructuring?))
                                                       (case (count new-bindings)
                                                             0 []
                                                             1 [(api/token-node (first new-bindings))
@@ -1018,12 +1025,14 @@
                                                            (first out)
                                                            (api/vector-node out))
                                                        (api/list-node expr)])
-                                     rebindings   (mapcat
-                                                   #(vector
-                                                     (api/token-node %)
-                                                     (api/list-node
-                                                      [(api/token-node 'identity) %]))
-                                                   rebinds)
+                                     rebindings   (if destructuring?
+                                                      []
+                                                      (mapcat
+                                                       #(vector
+                                                         (api/token-node %)
+                                                         (api/list-node
+                                                          [(api/token-node 'identity) %]))
+                                                       rebinds))
                                      anchor-binds (mapcat #(vector
                                                             %
                                                             (api/token-node nil))
@@ -1042,7 +1051,7 @@
                     ;;     ...follows))
                                      result
                                      (with-meta
-                                      (if rebinds
+                                      (if (and rebinds (not destructuring?))
                                           (api/list-node
                                            (list
                                             (api/token-node 'do)

--- a/clj-kondo.exports/com.rpl/rama/config.edn
+++ b/clj-kondo.exports/com.rpl/rama/config.edn
@@ -42,7 +42,7 @@
 
  :linters
  {:rama-syntax-error         {:level :error}
-  :rama-unverifiable-pobject {:level :info}
+  :rama-unverifiable-pobject {:level :off}
   :unused-namespace  {:exclude [com.rpl.rama com.rpl.rama.path]}
   :refer-all         {:exclude [com.rpl.rama com.rpl.rama.path]}
   ;; clj-kondo doesn't support (:require [... :refer :all]) or (:use ...) forms

--- a/test-regression/com/rpl/rama_hooks/fixtures/rama_tpcc_findings.edn
+++ b/test-regression/com/rpl/rama_hooks/fixtures/rama_tpcc_findings.edn
@@ -49,48 +49,6 @@
   :type :unused-binding,
   :message "unused binding *final-total"}
  {:filename "src/clj/rpl/tpcc.clj",
-  :row 635,
-  :col 3,
-  :level :info,
-  :type :rama-unverifiable-pobject,
-  :message
-  "Cannot verify that $$customer is declared in this module's scope"}
- {:filename "src/clj/rpl/tpcc.clj",
-  :row 635,
-  :col 3,
-  :level :info,
-  :type :rama-unverifiable-pobject,
-  :message
-  "Cannot verify that $$customer-by-last is declared in this module's scope"}
- {:filename "src/clj/rpl/tpcc.clj",
-  :row 635,
-  :col 3,
-  :level :info,
-  :type :rama-unverifiable-pobject,
-  :message
-  "Cannot verify that $$order is declared in this module's scope"}
- {:filename "src/clj/rpl/tpcc.clj",
-  :row 667,
-  :col 3,
-  :level :info,
-  :type :rama-unverifiable-pobject,
-  :message
-  "Cannot verify that $$district is declared in this module's scope"}
- {:filename "src/clj/rpl/tpcc.clj",
-  :row 667,
-  :col 3,
-  :level :info,
-  :type :rama-unverifiable-pobject,
-  :message
-  "Cannot verify that $$order is declared in this module's scope"}
- {:filename "src/clj/rpl/tpcc.clj",
-  :row 667,
-  :col 3,
-  :level :info,
-  :type :rama-unverifiable-pobject,
-  :message
-  "Cannot verify that $$stock is declared in this module's scope"}
- {:filename "src/clj/rpl/tpcc.clj",
   :row 689,
   :col 24,
   :level :error,
@@ -102,20 +60,6 @@
   :level :error,
   :type :unresolved-symbol,
   :message "Unresolved symbol: *cleanup-tick"}
- {:filename "src/clj/rpl/tpcc.clj",
-  :row 716,
-  :col 5,
-  :level :info,
-  :type :rama-unverifiable-pobject,
-  :message
-  "Cannot verify that *cleanup-tick is declared in this module's scope"}
- {:filename "src/clj/rpl/tpcc.clj",
-  :row 716,
-  :col 5,
-  :level :info,
-  :type :rama-unverifiable-pobject,
-  :message
-  "Cannot verify that *transaction-depot is declared in this module's scope"}
  {:filename "src/clj/rpl/tpcc.clj",
   :row 716,
   :col 5,

--- a/test-regression/com/rpl/rama_hooks/fixtures/rama_tpcc_findings.edn
+++ b/test-regression/com/rpl/rama_hooks/fixtures/rama_tpcc_findings.edn
@@ -37,17 +37,59 @@
   :type :unused-binding,
   :message "unused binding *d-tax"}
  {:filename "src/clj/rpl/tpcc.clj",
-  :row 398,
-  :col 16,
+  :row 400,
+  :col 47,
   :level :warning,
   :type :unused-binding,
   :message "unused binding *o-id"}
  {:filename "src/clj/rpl/tpcc.clj",
-  :row 441,
-  :col 21,
+  :row 443,
+  :col 12,
   :level :warning,
   :type :unused-binding,
   :message "unused binding *final-total"}
+ {:filename "src/clj/rpl/tpcc.clj",
+  :row 635,
+  :col 3,
+  :level :info,
+  :type :rama-unverifiable-pobject,
+  :message
+  "Cannot verify that $$customer is declared in this module's scope"}
+ {:filename "src/clj/rpl/tpcc.clj",
+  :row 635,
+  :col 3,
+  :level :info,
+  :type :rama-unverifiable-pobject,
+  :message
+  "Cannot verify that $$customer-by-last is declared in this module's scope"}
+ {:filename "src/clj/rpl/tpcc.clj",
+  :row 635,
+  :col 3,
+  :level :info,
+  :type :rama-unverifiable-pobject,
+  :message
+  "Cannot verify that $$order is declared in this module's scope"}
+ {:filename "src/clj/rpl/tpcc.clj",
+  :row 667,
+  :col 3,
+  :level :info,
+  :type :rama-unverifiable-pobject,
+  :message
+  "Cannot verify that $$district is declared in this module's scope"}
+ {:filename "src/clj/rpl/tpcc.clj",
+  :row 667,
+  :col 3,
+  :level :info,
+  :type :rama-unverifiable-pobject,
+  :message
+  "Cannot verify that $$order is declared in this module's scope"}
+ {:filename "src/clj/rpl/tpcc.clj",
+  :row 667,
+  :col 3,
+  :level :info,
+  :type :rama-unverifiable-pobject,
+  :message
+  "Cannot verify that $$stock is declared in this module's scope"}
  {:filename "src/clj/rpl/tpcc.clj",
   :row 689,
   :col 24,
@@ -60,6 +102,20 @@
   :level :error,
   :type :unresolved-symbol,
   :message "Unresolved symbol: *cleanup-tick"}
+ {:filename "src/clj/rpl/tpcc.clj",
+  :row 716,
+  :col 5,
+  :level :info,
+  :type :rama-unverifiable-pobject,
+  :message
+  "Cannot verify that *cleanup-tick is declared in this module's scope"}
+ {:filename "src/clj/rpl/tpcc.clj",
+  :row 716,
+  :col 5,
+  :level :info,
+  :type :rama-unverifiable-pobject,
+  :message
+  "Cannot verify that *transaction-depot is declared in this module's scope"}
  {:filename "src/clj/rpl/tpcc.clj",
   :row 716,
   :col 5,

--- a/test/com/rpl/rama_hooks/basic_test.clj
+++ b/test/com/rpl/rama_hooks/basic_test.clj
@@ -106,6 +106,44 @@
                  '(hash-map :one 1 :two 2 :> {:keys [*one *two]})
                  '(pr *one))))))
 
+  (testing "Destructuring rebinds"
+           (testing "uses destructuring when all output vars are rebinds"
+                    (is
+                     (= '(let [*a (identity 1)]
+                              (let [*b (identity 2)]
+                                   (let [[*a *b] (identity *x)]
+                                        (println *a *b))))
+                        (body->sexpr
+                         (transform-sexprs
+                          '(identity 1 :> *a)
+                          '(identity 2 :> *b)
+                          '(identity *x :> [*a *b])
+                          '(println *a *b))))))
+
+           (testing "uses destructuring when output has mix of new and rebound vars"
+                    (is
+                     (= '(let [*a (identity 1)]
+                              (let [[*a *b *c] (identity *x)]
+                                   (println *a *b *c)))
+                        (body->sexpr
+                         (transform-sexprs
+                          '(identity 1 :> *a)
+                          '(identity *x :> [*a *b *c])
+                          '(println *a *b *c))))))
+
+           (testing "uses map destructuring when all output vars are rebinds"
+                    (is
+                     (= '(let [*one (identity 1)]
+                              (let [*two (identity 2)]
+                                   (let [{:keys [*one *two]} (hash-map :one 10 :two 20)]
+                                        (pr *one *two))))
+                        (body->sexpr
+                         (transform-sexprs
+                          '(identity 1 :> *one)
+                          '(identity 2 :> *two)
+                          '(hash-map :one 10 :two 20 :> {:keys [*one *two]})
+                          '(pr *one *two)))))))
+
   (testing "Multiple assignments"
            (is
             (=

--- a/test/com/rpl/rama_hooks/special_forms_test.clj
+++ b/test/com/rpl/rama_hooks/special_forms_test.clj
@@ -173,16 +173,14 @@
     '(fn
       []
       (let [$$user-total-spend "$$user-total-spend"]
-           (do (microbatch)
-               (let
-                [*purchase-cents (microbatch)
-                 *user-id (identity *user-id)]
-                (|hash *user-id)
-                (let [[*total-spend-cents] []]
-                     (pr $$user-total-spend
-                         {*user-id (do (+sum *purchase-cents)
-                                       (let [*total-spend-cents (identity *total-spend-cents)]))})
-                     [*user-id *total-spend-cents])))))
+           (let
+            [{:keys [*user-id *purchase-cents]} (microbatch)]
+            (|hash *user-id)
+            (let [[*total-spend-cents] []]
+                 (pr $$user-total-spend
+                     {*user-id (do (+sum *purchase-cents)
+                                   (let [*total-spend-cents (identity *total-spend-cents)]))})
+                 [*user-id *total-spend-cents]))))
 
     (node->sexpr
      (rama/batch<--hook


### PR DESCRIPTION
## Summary

- Disable the `:rama-unverifiable-pobject` linter by default (level `:off`) since the info findings are noise for valid code in standalone topologies. Document in README how users can opt in.
- Fix destructuring emit rebinds: when all output variables in a destructuring emit (e.g. `(identity *x :> [*a *b *c])`) were already bound, the transformation generated broken self-referential rebinds like `*a (identity *a)` instead of preserving the destructuring pattern.

## Test plan

- [x] Unit tests pass (44 tests, 202 assertions)
- [x] Regression tests pass (3 assertions across 3 external projects)
- [x] New test cases cover vector and map destructuring with all-rebind and mixed new/rebind scenarios